### PR TITLE
Changed export approach from es6 to nodejs to fix the import issue

### DIFF
--- a/src/utils/DateLanguages.js
+++ b/src/utils/DateLanguages.js
@@ -1,4 +1,4 @@
-export default {
+module.exports = {
     translations: {
         'en': {
             'months': {


### PR DESCRIPTION
When I imported the Datepicker component to my webpack-powered app I received the following error in the browser console and a blank screen:

> DateLanguages.js?7072:1Uncaught SyntaxError: Unexpected token export

I noticed that DateUtils.js uses nodejs' export approach but DateLang uses es6's one.
Switching to nodejs' export approach fixed the issue.