### PR TITLE
Fix replacing d in month name

### DIFF
--- a/src/utils/DateUtils.js
+++ b/src/utils/DateUtils.js
@@ -134,14 +134,14 @@ export default {
     let month = date.getMonth() + 1
     let day = date.getDate()
     let str = format
+      .replace(/dd/, ('0' + day).slice(-2))
+      .replace(/d/, day)
       .replace(/yyyy/, year)
       .replace(/yy/, String(year).slice(2))
       .replace(/MMMM/, this.getMonthName(date.getMonth(), translation.months.original))
       .replace(/MMM/, this.getMonthNameAbbr(date.getMonth(), translation.months.abbr))
       .replace(/MM/, ('0' + month).slice(-2))
       .replace(/M(?!a)/, month)
-      .replace(/dd/, ('0' + day).slice(-2))
-      .replace(/d/, day)
       .replace(/su/, this.getNthSuffix(date.getDate()))
       .replace(/D(?!e)/, this.getDayNameAbbr(date, translation.days))
     return str


### PR DESCRIPTION
### Fix replacing d in month name:
How to reproduce the bug:
* Set language to Croatian: `language="hr"`
* Use format: `format="dd. MMMM yyyy"`
* Select any day in November (Croatian: Stu**d**eni) 
* Bug: Input value is **11. Stu11eni 2016** instead **11. Studeni 2016**

Fix: 
In _formatDate_ method replacing **d** and **dd** have to be before replacing month.