### PR TITLE
Implement Monday as first day of week support

### DIFF
--- a/src/Datepicker.vue
+++ b/src/Datepicker.vue
@@ -22,7 +22,7 @@
                     class="next"
                     v-bind:class="{ 'disabled' : nextMonthDisabled(currDate) }">&gt;</span>
             </header>
-            <span class="cell day-header" v-for="d in translation.days">{{ d }}</span>
+            <span class="cell day-header" v-for="d in daysOfWeek">{{ d }}</span>
             <span class="cell day blank" v-for="d in blankDays"></span><!--
             --><span class="cell day"
                 v-for="day in days"
@@ -108,6 +108,10 @@ export default {
     },
     wrapperClass: {
       type: String
+    },
+    mondayFirst: {
+      type: Boolean,
+      default: false
     }
   },
   data () {
@@ -170,7 +174,18 @@ export default {
     blankDays () {
       const d = new Date(this.currDate)
       let dObj = new Date(d.getFullYear(), d.getMonth(), 1, d.getHours(), d.getMinutes())
+      if (this.mondayFirst) {
+        return dObj.getDay() > 0 ? dObj.getDay() - 1 : 6
+      }
       return dObj.getDay()
+    },
+    daysOfWeek () {
+      if (this.mondayFirst) {
+        const tempDays = this.translation.days.slice()
+        tempDays.push(tempDays.shift())
+        return tempDays
+      }
+      return this.translation.days
     },
     days () {
       const d = new Date(this.currDate)

--- a/test/specs/Datepicker.spec.js
+++ b/test/specs/Datepicker.spec.js
@@ -439,3 +439,30 @@ describe('Datepicker has disabled dates but can change dates', () => {
     expect(vm.$refs.component.isDisabledDate(new Date(2016, 9, 3))).to.equal(false)
   })
 })
+
+describe('Datepicker with monday as first day of week', () => {
+  beforeEach(() => {
+    vm = new Vue({
+      template: '<div><datepicker :monday-first="true" language="en" v-ref:component></datepicker></div>',
+      components: { Datepicker }
+    }).$mount()
+  })
+
+  it('should return Monday as a first day of week', () => {
+    expect(vm.$refs.component.daysOfWeek[0]).to.equal('Mon')
+  })
+
+  it('should return Sunday as a seventh day of week', () => {
+    expect(vm.$refs.component.daysOfWeek[6]).to.equal('Sun')
+  })
+
+  it('should have 6 blankDays when month starts from Sunday', () => {
+    vm.$refs.component.currDate = new Date(2016, 4, 1).getTime()
+    expect(vm.$refs.component.blankDays).to.equal(6)
+  })
+
+  it('should have no blankDays when month starts from Monday', () => {
+    vm.$refs.component.currDate = new Date(2017, 4, 1).getTime()
+    expect(vm.$refs.component.blankDays).to.equal(0)
+  })
+})


### PR DESCRIPTION
In some countries Monday is always first day of a week. This changes
enable option to show Datepicker calendar with weeks starting from
Monday. Sunday still stays first by default.