### PR TITLE
CSS Selector `*` should be scoped

### DIFF
--- a/src/Datepicker.vue
+++ b/src/Datepicker.vue
@@ -720,11 +720,10 @@ export default {
 
 $width = 300px
 
-*
-    box-sizing border-box
-
 .datepicker
     position relative
+    *
+        box-sizing border-box
 
 .calendar
     position absolute


### PR DESCRIPTION
CSS Selector `*` is exposed global and affects other components.
Could we move this into under `.datepicker`?