### PR TITLE
Made full bootstrap styling possible + added calendar button

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Inline always open version
 | wrapper-class         | String       |             | css class applied to the outer div       |
 | monday-first          | Boolean      | false       | To start the week on Monday              |
 | clear-button          | Boolean      | false       | Show an icon for clearing the date       |
-| clear-button-icon     | String       |             | Use icon for button (ex: fa fa-close)    |
+| clear-button-icon     | String       |             | Use icon for button (ex: fa fa-times)    |
 | calendar-button       | Boolean      | false       | Show an icon that that can be clicked    |
 | calendar-button-icon  | String       |             | Use icon for button (ex: fa fa-calendar) |
 | bootstrapStyling      | Boolean      | false       | Output bootstrap styling classes         |

--- a/README.md
+++ b/README.md
@@ -58,20 +58,23 @@ Inline always open version
 ```
 ## Available props
 
-| Prop          | Type         | Default     | Description                         |
-|---------------|--------------|-------------|-------------------------------------|
-| value         | Date/String  |             | Date value of the datepicker        |
-| name          | String       |             | input name property                 |
-| id            | String       |             | input id                            |
-| format        | String       | dd MMM yyyy | Date formatting string              |
-| language      | String       | en          | Translation for days and months     |
-| disabled      | Object       |             | See below for configuration         |
-| placeholder   | String       |             | input placeholder text              |
-| inline        | Boolean      |             | to show the datepicker always open  |
-| input-class   | String       |             | css class applied to the input el   |
-| wrapper-class | String       |             | css class applied to the outer div  |
-| monday-first  | Boolean      | false       | To start the week on Monday         |
-| clear-button   | Boolean     | false       | Show an icon for clearing the date |
+| Prop                  | Type         | Default     | Description                              |
+|-----------------------|--------------|-------------|------------------------------------------|
+| value                 | Date/String  |             | Date value of the datepicker             |
+| name                  | String       |             | input name property                      |
+| id                    | String       |             | input id                                 |
+| format                | String       | dd MMM yyyy | Date formatting string                   |
+| language              | String       | en          | Translation for days and months          |
+| disabled              | Object       |             | See below for configuration              |
+| placeholder           | String       |             | input placeholder text                   |
+| inline                | Boolean      |             | to show the datepicker always open       |
+| input-class           | String       |             | css class applied to the input el        |
+| wrapper-class         | String       |             | css class applied to the outer div       |
+| monday-first          | Boolean      | false       | To start the week on Monday              |
+| clear-button          | Boolean      | false       | Show an icon for clearing the date       |
+| clear-button-icon     | String       |             | Use icon for button (ex: fa fa-close)    |
+| calendar-button       | Boolean      | false       | Show an icon that that can be clicked    |
+| calendar-button-icon  | String       |             | Use icon for button (ex: fa fa-calendar) |
 
 ## Date formatting
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Inline always open version
 | clear-button-icon     | String       |             | Use icon for button (ex: fa fa-close)    |
 | calendar-button       | Boolean      | false       | Show an icon that that can be clicked    |
 | calendar-button-icon  | String       |             | Use icon for button (ex: fa fa-calendar) |
+| bootstrapStyling      | Boolean      | false       | Output bootstrap styling classes         |
 
 ## Date formatting
 

--- a/index.html
+++ b/index.html
@@ -3,18 +3,9 @@
   <head>
     <meta charset="utf-8">
     <title>Vue.js Datepicker</title>
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" />
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" />
   </head>
   <body>
-    <div class="col-3">
-      <br />
-      <datepicker format="D dsu MMM yyyy" :bootstrap-styling="true" :calendar-button="true" :clear-button="true"></datepicker>
-    </div>
-    <div class="col-3">
-      <br />
-      <datepicker format="D dsu MMM yyyy"></datepicker>
-    </div>
+    <datepicker format="D dsu MMM yyyy"></datepicker>
     <script src="dist/build.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -3,18 +3,9 @@
   <head>
     <meta charset="utf-8">
     <title>Vue.js Datepicker</title>
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" />
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
   </head>
   <body>
-    <div class="container pt-4">
-      <br />
-      <div class="form-group row">
-      <div class="col-sm-10">
-      <datepicker format="D dsu MMM yyyy" input-class="form-control" :clear-button="true" clear-button-icon="fa fa-close" :calendar-button="true" calendar-button-icon="fa fa-calendar"></datepicker>
-      </div>
-      </div>
-    </div>
+    <datepicker format="D dsu MMM yyyy"></datepicker>
     <script src="dist/build.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -3,9 +3,18 @@
   <head>
     <meta charset="utf-8">
     <title>Vue.js Datepicker</title>
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" />
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.6/css/bootstrap.min.css" integrity="sha384-rwoIResjU2yc3z8GV/NPeZWAv56rSmLldC3R/AZzGRnGxQQKnKkoFVhFQhNUwEyJ" crossorigin="anonymous">
   </head>
   <body>
-    <datepicker format="D dsu MMM yyyy"></datepicker>
+    <div class="container pt-4">
+      <br />
+      <div class="form-group row">
+      <div class="col-sm-10">
+      <datepicker format="D dsu MMM yyyy" input-class="form-control" :clear-button="true" clear-button-icon="fa fa-close" :calendar-button="true" calendar-button-icon="fa fa-calendar"></datepicker>
+      </div>
+      </div>
+    </div>
     <script src="dist/build.js"></script>
   </body>
 </html>

--- a/src/Datepicker.vue
+++ b/src/Datepicker.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="vdp-datepicker" :class="wrapperClass">
     <div :class="{'input-group' : bootstrapStyling}">
-      <span class="vdp-datepicker__calendar-button" :class="{'input-group-addon' : bootstrapStyling}" v-if="calendarButton" @click="showCalendar()"><i :class="calendarButtonIcon"><span v-if="calendarButtonIcon.length == 0">&hellip;</span></i></span>
+      <span class="vdp-datepicker__calendar-button" :class="{'input-group-addon' : bootstrapStyling}" v-if="calendarButton" @click="showCalendar()"><i :class="calendarButtonIcon"><span v-if="calendarButtonIcon.length === 0">&hellip;</span></i></span>
       <input
         :type="inline ? 'hidden' : 'text'"
         :class="[ inputClass, { 'form-control' : bootstrapStyling } ]"
@@ -14,7 +14,7 @@
         :disabled="disabledPicker"
         :required="required"
         readonly>
-      <span class="vdp-datepicker__clear-button" :class="{'input-group-addon' : bootstrapStyling}" v-if="clearButton && selectedDate" @click="clearDate()"><i :class="clearButtonIcon"><span v-if="calendarButtonIcon.length == 0">&times;</span></i></span>
+      <span class="vdp-datepicker__clear-button" :class="{'input-group-addon' : bootstrapStyling}" v-if="clearButton && selectedDate" @click="clearDate()"><i :class="clearButtonIcon"><span v-if="calendarButtonIcon.length === 0">&times;</span></i></span>
     </div>
         <!-- Day View -->
         <div class="vdp-datepicker__calendar" v-show="showDayView" v-bind:style="calendarStyle">

--- a/src/Datepicker.vue
+++ b/src/Datepicker.vue
@@ -1,18 +1,19 @@
 <template>
   <div class="datepicker" :class="wrapperClass">
-        <div class="input-group">
-            <span class="datepicker-calendar-button input-group-addon" v-if="calendarButton" @click="showCalendar()"><i :class="calendarButtonIcon"><span v-if="calendarButtonIcon.length == 0">&hellip;</span></i></span>
+        <div :class="{'input-group' : bootstrapStyling}">
+            <span class="datepicker-calendar-button" :class="{'input-group-addon' : bootstrapStyling}" v-if="calendarButton" @click="showCalendar()"><i :class="calendarButtonIcon"><span v-if="calendarButtonIcon.length == 0">&hellip;</span></i></span>
             <input
-                :type="inline ? 'hidden' : 'text'"
-                :class="inputClass"
-                :name="name"
-                :id="id"
-                @click="showCalendar()"
-                :value="formattedValue"
-                :placeholder="placeholder"
-                readonly>
-            <span class="datepicker-clear-button input-group-addon" v-if="clearButton" @click="clearDate()"><i :class="clearButtonIcon"><span v-if="calendarButtonIcon.length == 0">&times;</span></i></span>
+                    :type="inline ? 'hidden' : 'text'"
+                    :class="[ inputClass, { 'form-control' : bootstrapStyling } ]"
+                    :name="name"
+                    :id="id"
+                    @click="showCalendar()"
+                    :value="formattedValue"
+                    :placeholder="placeholder"
+                    readonly>
+            <span class="datepicker-clear-button" :class="{'input-group-addon' : bootstrapStyling}" v-if="clearButton" @click="clearDate()"><i :class="clearButtonIcon"><span v-if="calendarButtonIcon.length == 0">&times;</span></i></span>
         </div>
+
         <!-- Day View -->
         <div class="calendar" v-show="showDayView" v-bind:style="calendarStyle">
             <header>
@@ -137,6 +138,10 @@ export default {
     calendarButtonIcon: {
       type: String,
       default: ''
+    },
+    bootstrapStyling: {
+      type: Boolean,
+      default: false
     }
   },
   data () {

--- a/src/Datepicker.vue
+++ b/src/Datepicker.vue
@@ -129,6 +129,22 @@ export default {
       type: Boolean,
       default: false
     },
+    clearButtonIcon: {
+      type: String,
+      default: ''
+    },
+    calendarButton: {
+      type: Boolean,
+      default: false
+    },
+    calendarButtonIcon: {
+      type: String,
+      default: ''
+    },
+    bootstrapStyling: {
+      type: Boolean,
+      default: false
+    },
     disabledPicker: {
       type: Boolean,
       default: false

--- a/src/Datepicker.vue
+++ b/src/Datepicker.vue
@@ -1,16 +1,18 @@
 <template>
   <div class="datepicker" :class="wrapperClass">
-    <input
-        :type="inline ? 'hidden' : 'text'"
-        :class="inputClass"
-        :name="name"
-        :id="id"
-        @click="showCalendar()"
-        :value="formattedValue"
-        :placeholder="placeholder"
-        :clear-button="clearButton"
-        readonly>
-    <i class="datepicker-clear-button" v-if="clearButton" @click="clearDate()">&times;</i>
+        <div class="input-group">
+            <span class="datepicker-calendar-button input-group-addon" v-if="calendarButton" @click="showCalendar()"><i :class="calendarButtonIcon"><span v-if="calendarButtonIcon.length == 0">&hellip;</span></i></span>
+            <input
+                :type="inline ? 'hidden' : 'text'"
+                :class="inputClass"
+                :name="name"
+                :id="id"
+                @click="showCalendar()"
+                :value="formattedValue"
+                :placeholder="placeholder"
+                readonly>
+            <span class="datepicker-clear-button input-group-addon" v-if="clearButton" @click="clearDate()"><i :class="clearButtonIcon"><span v-if="calendarButtonIcon.length == 0">&times;</span></i></span>
+        </div>
         <!-- Day View -->
         <div class="calendar" v-show="showDayView" v-bind:style="calendarStyle">
             <header>
@@ -123,6 +125,18 @@ export default {
     clearButton: {
       type: Boolean,
       default: false
+    },
+    clearButtonIcon: {
+      type: String,
+      default: ''
+    },
+    calendarButton: {
+      type: Boolean,
+      default: false
+    },
+    calendarButtonIcon: {
+      type: String,
+      default: ''
     }
   },
   data () {
@@ -836,7 +850,7 @@ $width = 300px
     .year
         width 33.333%
 
-.datepicker-clear-button
+.datepicker-clear-button, .datepicker-calendar-button
     cursor: pointer
     font-style: normal
 </style>


### PR DESCRIPTION
Hi Charlie

Thanks for the addon, we are using Bootstrap and are running into a few issues with the output of the component. Don't know if you are open for it, but these modifications makes bootstrap styling possible and adds the following features:

- calendar button that activates the calendar
- possibility to use icons (font awsome or glyphicons) in the buttons (calendar + clear)

Usage would be:

`<datepicker format="D dsu MMM yyyy" :bootstrap-styling="true" :calendar-button="true" :clear-button="true" calendar-button-icon="fa fa-calendar" clear-button-icon="fa fa-times"></datepicker>`

or for glyphicon
`<datepicker format="D dsu MMM yyyy" :bootstrap-styling="true" :calendar-button="true" :clear-button="true" calendar-button-icon="glyphicon glyphicon-calendar" clear-button-icon="glyphicon glyphicon-remove"></datepicker>`

Cheers Adam