### PR TITLE
Add disabled-picker property to enable a full disabled state on component

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Inline always open version
 | wrapper-class | String       |             | css class applied to the outer div  |
 | monday-first  | Boolean      | false       | To start the week on Monday         |
 | clear-button   | Boolean     | false       | Show an icon for clearing the date |
+| disabled-picker | Boolean     | false       | If true, disable Datepicker on screen | 
 
 ## Date formatting
 

--- a/src/Datepicker.vue
+++ b/src/Datepicker.vue
@@ -9,6 +9,7 @@
         :value="formattedValue"
         :placeholder="placeholder"
         :clear-button="clearButton"
+        :disabled="disabledPicker"
         readonly>
     <i class="datepicker-clear-button" v-if="clearButton" @click="clearDate()">&times;</i>
         <!-- Day View -->
@@ -121,6 +122,10 @@ export default {
       default: false
     },
     clearButton: {
+      type: Boolean,
+      default: false
+    },
+    disabledPicker: {
       type: Boolean,
       default: false
     }


### PR DESCRIPTION
The property disabled-picker has been added to enable a full component disabled state.

The property is of type Boolean and has a default of false, when ser to true the input field inside the component get disabled, and as a consecuense of that the mouse click stops working, so the component get into a read only mode, until the property gets back to true, that reenables the input field and the date can be changed angain.

Hope this simple functionality can be merged soon, since it has been comented by some others and is very usefull for read only situations.
