### PR TITLE
Emit a closed event when date picker closed

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Use `v-model` for two-way binding
 ```
 Emits events
 ``` html
-<datepicker v-on:selected="doSomethingInParentComponentFunction" v-on:opened="datepickerOpenedFunction">
+<datepicker v-on:selected="doSomethingInParentComponentFunction" v-on:opened="datepickerOpenedFunction" v-on:closed="datepickerClosedFunction">
 ```
 Inline always open version
 ``` html
@@ -72,8 +72,8 @@ Inline always open version
 | wrapper-class   | String       |             | css class applied to the outer div    |
 | monday-first    | Boolean      | false       | To start the week on Monday           |
 | clear-button    | Boolean      | false       | Show an icon for clearing the date    |
-| disabled-picker | Boolean      | false       | If true, disable Datepicker on screen | 
-| required        | Boolean      | false       | Sets html required attribute on input | 
+| disabled-picker | Boolean      | false       | If true, disable Datepicker on screen |
+| required        | Boolean      | false       | Sets html required attribute on input |
 
 ## Date formatting
 

--- a/src/Datepicker.vue
+++ b/src/Datepicker.vue
@@ -286,6 +286,7 @@ export default {
   methods: {
     close () {
       this.showDayView = this.showMonthView = this.showYearView = false
+      this.$emit('closed')
     },
     getDefaultDate () {
       return new Date(new Date().getFullYear(), new Date().getMonth(), 1).getTime()


### PR DESCRIPTION
Added an event 'closed' that is triggered anytime the date picker is closed. This is helpful is you need to do something reactive based on the date picker closing. In my case I'm using the date picker inside an iframe and need to resize the iframe anytime the height of the framed page changes, so I need to know when the datepicker closes so I can recalculate the height.