### PR TITLE
fixed resetDefaultDate(): let currDate is the first of the month

### DIFF
--- a/src/Datepicker.vue
+++ b/src/Datepicker.vue
@@ -308,7 +308,7 @@ export default {
         this.currDate = this.getDefaultDate()
         return
       }
-      this.currDate = this.selectedDate.getTime()
+      this.currDate = this.currDate = new Date(this.selectedDate.getFullYear(), this.selectedDate.getMonth(), 1).getTime()
     },
     /**
      * Effectively a toggle to show/hide the calendar

--- a/test/specs/Datepicker.spec.js
+++ b/test/specs/Datepicker.spec.js
@@ -192,10 +192,10 @@ describe('Datepicker.vue', () => {
   it('can set the next month correctly on the last day of a 31 day month', () => {
     const date = new Date(2017, 4, 31)
     vm.$refs.component.selectDate({timestamp: date.getTime()})
+    // when click document to close the modal will run resetDefaultDate();
+    vm.$refs.component.resetDefaultDate()
     vm.$refs.component.nextMonth()
     expect(vm.$refs.component.getMonth()).to.equal(5)
-    vm.$refs.component.nextMonth()
-    expect(vm.$refs.component.getMonth()).to.equal(6)
   })
 
   it('can set the previous month', () => {


### PR DESCRIPTION
[issue:  bug: nextMonth's button #156](https://github.com/charliekassel/vuejs-datepicker/issues/156)