### PR TITLE
Time

### DIFF
--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -307,14 +307,14 @@ export default {
       }
     },
     getDefaultDate () {
-      return new Date(new Date().getFullYear(), new Date().getMonth(), 1).getTime()
+      return new Date().getTime() // new Date().getFullYear(), new Date().getMonth(), 1).getTime()
     },
     resetDefaultDate () {
       if (this.selectedDate === null) {
         this.currDate = this.getDefaultDate()
         return
       }
-      this.currDate = this.currDate = new Date(this.selectedDate.getFullYear(), this.selectedDate.getMonth(), 1).getTime()
+      this.currDate = new Date(this.selectedDate).getTime() // .getFullYear(), this.selectedDate.getMonth(), 1).getTime()
     },
     /**
      * Effectively a toggle to show/hide the calendar
@@ -364,7 +364,7 @@ export default {
 
     setDate (timestamp) {
       this.selectedDate = new Date(timestamp)
-      this.currDate = new Date(this.selectedDate.getFullYear(), this.selectedDate.getMonth(), 1).getTime()
+      this.currDate = new Date(this.selectedDate).getTime() // .getFullYear(), this.selectedDate.getMonth(), 1).getTime()
       this.$emit('selected', new Date(timestamp))
       this.$emit('input', new Date(timestamp))
     },
@@ -744,13 +744,13 @@ export default {
         date = isNaN(parsed.valueOf()) ? null : parsed
       }
       if (!date) {
-        const d = new Date()
-        this.currDate = new Date(d.getFullYear(), d.getMonth(), 1).getTime()
+        // const d = new Date()
+        this.currDate = new Date().getTime() // d.getFullYear(), d.getMonth(), 1).getTime()
         this.selectedDate = null
         return
       }
       this.selectedDate = date
-      this.currDate = new Date(date.getFullYear(), date.getMonth(), 1).getTime()
+      this.currDate = new Date().getTime() // date.getFullYear(), date.getMonth(), 1).getTime()
     },
 
     /**

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -23,12 +23,12 @@
                 <span
                     @click="previousMonth"
                     class="prev"
-                    v-bind:class="{ 'disabled' : previousMonthDisabled(currDate) }">&lt;</span>
+                    v-bind:class="{ 'disabled' : previousMonthDisabled(pageDate) }">&lt;</span>
                 <span @click="showMonthCalendar" class="up">{{ currMonthName }} {{ currYear }}</span>
                 <span
                     @click="nextMonth"
                     class="next"
-                    v-bind:class="{ 'disabled' : nextMonthDisabled(currDate) }">&gt;</span>
+                    v-bind:class="{ 'disabled' : nextMonthDisabled(pageDate) }">&gt;</span>
             </header>
             <span class="cell day-header" v-for="d in daysOfWeek">{{ d }}</span>
             <span class="cell day blank" v-for="d in blankDays"></span><!--
@@ -45,12 +45,12 @@
                 <span
                     @click="previousYear"
                     class="prev"
-                    v-bind:class="{ 'disabled' : previousYearDisabled(currDate) }">&lt;</span>
-                <span @click="showYearCalendar" class="up">{{ getYear() }}</span>
+                    v-bind:class="{ 'disabled' : previousYearDisabled(pageDate) }">&lt;</span>
+                <span @click="showYearCalendar" class="up">{{ getPageYear() }}</span>
                 <span
                     @click="nextYear"
                     class="next"
-                    v-bind:class="{ 'disabled' : nextYearDisabled(currDate) }">&gt;</span>
+                    v-bind:class="{ 'disabled' : nextYearDisabled(pageDate) }">&gt;</span>
             </header>
             <span class="cell month"
                 v-for="month in months"
@@ -63,10 +63,10 @@
         <div class="vdp-datepicker__calendar" v-show="showYearView" v-bind:style="calendarStyle">
             <header>
                 <span @click="previousDecade" class="prev"
-                    v-bind:class="{ 'disabled' : previousDecadeDisabled(currDate) }">&lt;</span>
-                <span>{{ getDecade() }}</span>
+                    v-bind:class="{ 'disabled' : previousDecadeDisabled(pageDate) }">&lt;</span>
+                <span>{{ getPageDecade() }}</span>
                 <span @click="nextDecade" class="next"
-                    v-bind:class="{ 'disabled' : nextMonthDisabled(currDate) }">&gt;</span>
+                    v-bind:class="{ 'disabled' : nextMonthDisabled(pageDate) }">&gt;</span>
             </header>
             <span
                 class="cell year"
@@ -165,7 +165,7 @@ export default {
        * This represents the first day of the current viewing month
        * {Number}
        */
-      currDate: new Date(new Date().getFullYear(), new Date().getMonth(), 1).getTime(),
+      pageDate: new Date(new Date().getFullYear(), new Date().getMonth(), 1, new Date().getHours(), new Date().getMinutes()).getTime(),
       /*
        * Selected Date
        * {Date}
@@ -200,11 +200,11 @@ export default {
       return DateLanguages.translations[this.language]
     },
     currMonthName () {
-      const d = new Date(this.currDate)
+      const d = new Date(this.pageDate)
       return DateUtils.getMonthNameAbbr(d.getMonth(), this.translation.months.abbr)
     },
     currYear () {
-      const d = new Date(this.currDate)
+      const d = new Date(this.pageDate)
       return d.getFullYear()
     },
     /**
@@ -213,7 +213,7 @@ export default {
      * @return {Number}
      */
     blankDays () {
-      const d = new Date(this.currDate)
+      const d = new Date(this.pageDate)
       let dObj = new Date(d.getFullYear(), d.getMonth(), 1, d.getHours(), d.getMinutes())
       if (this.mondayFirst) {
         return dObj.getDay() > 0 ? dObj.getDay() - 1 : 6
@@ -229,7 +229,7 @@ export default {
       return this.translation.days
     },
     days () {
-      const d = new Date(this.currDate)
+      const d = new Date(this.pageDate)
       let days = []
       // set up a new date object to the beginning of the current 'page'
       let dObj = new Date(d.getFullYear(), d.getMonth(), 1, d.getHours(), d.getMinutes())
@@ -248,7 +248,7 @@ export default {
       return days
     },
     months () {
-      const d = new Date(this.currDate)
+      const d = new Date(this.pageDate)
       let months = []
       // set up a new date object to the beginning of the current 'page'
       let dObj = new Date(d.getFullYear(), 0, d.getDate(), d.getHours(), d.getMinutes())
@@ -264,7 +264,7 @@ export default {
       return months
     },
     years () {
-      const d = new Date(this.currDate)
+      const d = new Date(this.pageDate)
       let years = []
       // set up a new date object to the beginning of the current 'page'
       let dObj = new Date(Math.floor(d.getFullYear() / 10) * 10, d.getMonth(), d.getDate(), d.getHours(), d.getMinutes())
@@ -306,15 +306,12 @@ export default {
         document.removeEventListener('click', this.clickOutside, false)
       }
     },
-    getDefaultDate () {
-      return new Date().getTime() // new Date().getFullYear(), new Date().getMonth(), 1).getTime()
-    },
     resetDefaultDate () {
       if (this.selectedDate === null) {
-        this.currDate = this.getDefaultDate()
+        this.setPageDate()
         return
       }
-      this.currDate = new Date(this.selectedDate).getTime() // .getFullYear(), this.selectedDate.getMonth(), 1).getTime()
+      this.setPageDate(this.selectedDate)
     },
     /**
      * Effectively a toggle to show/hide the calendar
@@ -363,10 +360,11 @@ export default {
     },
 
     setDate (timestamp) {
-      this.selectedDate = new Date(timestamp)
-      this.currDate = new Date(this.selectedDate).getTime() // .getFullYear(), this.selectedDate.getMonth(), 1).getTime()
-      this.$emit('selected', new Date(timestamp))
-      this.$emit('input', new Date(timestamp))
+      const date = new Date(timestamp)
+      this.selectedDate = new Date(date)
+      this.setPageDate(date)
+      this.$emit('selected', new Date(date))
+      this.$emit('input', new Date(date))
     },
 
     clearDate () {
@@ -397,7 +395,8 @@ export default {
       if (month.isDisabled) {
         return false
       }
-      this.currDate = month.timestamp
+      const date = new Date(month.timestamp)
+      this.setPageDate(date)
       this.showDayCalendar()
       this.$emit('changedMonth', month)
     },
@@ -409,7 +408,8 @@ export default {
       if (year.isDisabled) {
         return false
       }
-      this.currDate = year.timestamp
+      const date = new Date(year.timestamp)
+      this.setPageDate(date)
       this.showMonthCalendar()
       this.$emit('changedYear', year)
     },
@@ -417,25 +417,33 @@ export default {
     /**
      * @return {Number}
      */
-    getMonth () {
-      let d = new Date(this.currDate)
-      return d.getMonth()
+    getPageDate () {
+      let date = new Date(this.pageDate)
+      return date.getDate()
     },
 
     /**
      * @return {Number}
      */
-    getYear () {
-      let d = new Date(this.currDate)
-      return d.getFullYear()
+    getPageMonth () {
+      let date = new Date(this.pageDate)
+      return date.getMonth()
+    },
+
+    /**
+     * @return {Number}
+     */
+    getPageYear () {
+      let date = new Date(this.pageDate)
+      return date.getFullYear()
     },
 
     /**
      * @return {String}
      */
-    getDecade () {
-      let d = new Date(this.currDate)
-      let sD = Math.floor(d.getFullYear() / 10) * 10
+    getPageDecade () {
+      let date = new Date(this.pageDate)
+      let sD = Math.floor(date.getFullYear() / 10) * 10
       return sD + '\'s'
     },
 
@@ -443,17 +451,17 @@ export default {
       if (this.previousMonthDisabled()) {
         return false
       }
-      let d = new Date(this.currDate)
-      d.setMonth(d.getMonth() - 1)
-      this.currDate = d.getTime()
-      this.$emit('changedMonth', d)
+      let date = new Date(this.pageDate)
+      date.setMonth(date.getMonth() - 1)
+      this.setPageDate(date)
+      this.$emit('changedMonth', date)
     },
 
     previousMonthDisabled () {
       if (typeof this.disabled === 'undefined' || typeof this.disabled.to === 'undefined' || !this.disabled.to) {
         return false
       }
-      let d = new Date(this.currDate)
+      let d = new Date(this.pageDate)
       if (
         this.disabled.to.getMonth() >= d.getMonth() &&
         this.disabled.to.getFullYear() >= d.getFullYear()
@@ -467,18 +475,17 @@ export default {
       if (this.nextMonthDisabled()) {
         return false
       }
-      let d = new Date(this.currDate)
-      const daysInMonth = DateUtils.daysInMonth(d.getFullYear(), d.getMonth())
-      d.setDate(d.getDate() + daysInMonth)
-      this.currDate = d.getTime()
-      this.$emit('changedMonth', d)
+      let date = new Date(this.pageDate)
+      date.setMonth(date.getMonth() + 1)
+      this.setPageDate(date)
+      this.$emit('changedMonth', date)
     },
 
     nextMonthDisabled () {
       if (typeof this.disabled === 'undefined' || typeof this.disabled.from === 'undefined' || !this.disabled.from) {
         return false
       }
-      let d = new Date(this.currDate)
+      let d = new Date(this.pageDate)
       if (
         this.disabled.from.getMonth() <= d.getMonth() &&
         this.disabled.from.getFullYear() <= d.getFullYear()
@@ -492,9 +499,9 @@ export default {
       if (this.previousYearDisabled()) {
         return false
       }
-      let d = new Date(this.currDate)
-      d.setYear(d.getFullYear() - 1)
-      this.currDate = d.getTime()
+      let date = new Date(this.pageDate)
+      date.setYear(date.getFullYear() - 1)
+      this.setPageDate(date)
       this.$emit('changedYear')
     },
 
@@ -502,7 +509,7 @@ export default {
       if (typeof this.disabled === 'undefined' || typeof this.disabled.to === 'undefined' || !this.disabled.to) {
         return false
       }
-      let d = new Date(this.currDate)
+      let d = new Date(this.pageDate)
       if (this.disabled.to.getFullYear() >= d.getFullYear()) {
         return true
       }
@@ -513,9 +520,9 @@ export default {
       if (this.nextYearDisabled()) {
         return false
       }
-      let d = new Date(this.currDate)
-      d.setYear(d.getFullYear() + 1)
-      this.currDate = d.getTime()
+      let date = new Date(this.pageDate)
+      date.setYear(date.getFullYear() + 1)
+      this.setPageDate(date)
       this.$emit('changedYear')
     },
 
@@ -523,7 +530,7 @@ export default {
       if (typeof this.disabled === 'undefined' || typeof this.disabled.from === 'undefined' || !this.disabled.from) {
         return false
       }
-      let d = new Date(this.currDate)
+      let d = new Date(this.pageDate)
       if (this.disabled.from.getFullYear() <= d.getFullYear()) {
         return true
       }
@@ -534,9 +541,9 @@ export default {
       if (this.previousDecadeDisabled()) {
         return false
       }
-      let d = new Date(this.currDate)
-      d.setYear(d.getFullYear() - 10)
-      this.currDate = d.getTime()
+      let date = new Date(this.pageDate)
+      date.setYear(date.getFullYear() - 10)
+      this.setPageDate(date)
       this.$emit('changedDecade')
     },
 
@@ -544,7 +551,7 @@ export default {
       if (typeof this.disabled === 'undefined' || typeof this.disabled.to === 'undefined' || !this.disabled.to) {
         return false
       }
-      let d = new Date(this.currDate)
+      let d = new Date(this.pageDate)
       if (Math.floor(this.disabled.to.getFullYear() / 10) * 10 >= Math.floor(d.getFullYear() / 10) * 10) {
         return true
       }
@@ -555,9 +562,9 @@ export default {
       if (this.nextDecadeDisabled()) {
         return false
       }
-      let d = new Date(this.currDate)
-      d.setYear(d.getFullYear() + 10)
-      this.currDate = d.getTime()
+      let date = new Date(this.pageDate)
+      date.setYear(date.getFullYear() + 10)
+      this.setPageDate(date)
       this.$emit('changedDecade')
     },
 
@@ -565,7 +572,7 @@ export default {
       if (typeof this.disabled === 'undefined' || typeof this.disabled.from === 'undefined' || !this.disabled.from) {
         return false
       }
-      let d = new Date(this.currDate)
+      let d = new Date(this.pageDate)
       if (Math.ceil(this.disabled.from.getFullYear() / 10) * 10 <= Math.ceil(d.getFullYear() / 10) * 10) {
         return true
       }
@@ -744,13 +751,19 @@ export default {
         date = isNaN(parsed.valueOf()) ? null : parsed
       }
       if (!date) {
-        // const d = new Date()
-        this.currDate = new Date().getTime() // d.getFullYear(), d.getMonth(), 1).getTime()
+        this.setPageDate()
         this.selectedDate = null
         return
       }
       this.selectedDate = date
-      this.currDate = new Date().getTime() // date.getFullYear(), date.getMonth(), 1).getTime()
+      this.setPageDate(date)
+    },
+
+    setPageDate (date) {
+      if (!date) {
+        date = new Date()
+      }
+      this.pageDate = new Date(date.getFullYear(), date.getMonth(), 1, date.getHours(), date.getMinutes()).getTime()
     },
 
     /**

--- a/src/utils/DateUtils.js
+++ b/src/utils/DateUtils.js
@@ -65,38 +65,13 @@ export default {
   },
 
   /**
-   * Returns a UTC date with timezone information removed
-   * @param {Date} date
-   * @return {Date}
-   */
-  convertToUTC (date) {
-    return new Date(date.getTime() + (date.getTimezoneOffset() * 60000))
-  },
-
-  /**
-   * Return the number of days in the month
+   * Alternative get total number of days in month
    * @param {Number} year
-   * @param {Number} month - month here is equal to getMonth() i.e index based
+   * @param {Number} m
    * @return {Number}
    */
   daysInMonth (year, month) {
-    return new Date(Date.UTC(year, month + 1, 0)).getUTCDate()
-  },
-
-  /**
-   * Returns number of days between two dates
-   * @param {Date} start
-   * @param {Date} end
-   * @return {Number}
-   */
-  dayDiff (start, end) {
-    const MS_PER_DAY = 1000 * 60 * 60 * 24
-
-    // Discard the time and time-zone information.
-    let utc1 = Date.UTC(start.getFullYear(), start.getMonth(), start.getDate())
-    let utc2 = Date.UTC(end.getFullYear(), end.getMonth(), end.getDate())
-
-    return Math.floor((utc2 - utc1) / MS_PER_DAY)
+    return /8|3|5|10/.test(month) ? 30 : month === 1 ? (!(year % 4) && year % 100) || !(year % 400) ? 29 : 28 : 31
   },
 
   /**

--- a/test/unit/specs/DateUtils.spec.js
+++ b/test/unit/specs/DateUtils.spec.js
@@ -59,19 +59,10 @@ describe('DateUtils', () => {
     })
   })
 
-  it('gives total days between two dates', () => {
-    expect(DateUtils.dayDiff(new Date(2016, 9, 5), new Date(2016, 9, 6))).to.equal(1)
-  })
-
   it('gives days in a month', () => {
     expect(DateUtils.daysInMonth(2016, 0)).to.equal(31)
     expect(DateUtils.daysInMonth(2016, 1)).to.equal(29)
     expect(DateUtils.daysInMonth(2016, 2)).to.equal(31)
-  })
-
-  it('converts to UTC. This is not a test...', () => {
-    const d = new Date()
-    expect(DateUtils.convertToUTC(d).getTime()).to.equal(d.getTime() + (d.getTimezoneOffset() * 60000))
   })
 
   it('getDayNameAbbr moans if date is not a Date object', () => {
@@ -108,5 +99,22 @@ describe('DateUtils', () => {
 
   it('getMonthName accepts a number', () => {
     expect(DateUtils.getMonthNameAbbr(3, DateLanguages.translations.en.months.abbr)).to.equal('Apr')
+  })
+})
+
+describe('daysInMonth', () => {
+  it('should give the correct days in a month', () => {
+    expect(DateUtils.daysInMonth(2017, 0)).to.equal(31) // Jan
+    expect(DateUtils.daysInMonth(2017, 1)).to.equal(28) // Feb
+    expect(DateUtils.daysInMonth(2017, 2)).to.equal(31) // Mar
+    expect(DateUtils.daysInMonth(2017, 3)).to.equal(30) // Apr
+    expect(DateUtils.daysInMonth(2017, 4)).to.equal(31) // May
+    expect(DateUtils.daysInMonth(2017, 5)).to.equal(30) // Jun
+    expect(DateUtils.daysInMonth(2017, 6)).to.equal(31) // Jul
+    expect(DateUtils.daysInMonth(2017, 7)).to.equal(31) // Aug
+    expect(DateUtils.daysInMonth(2017, 8)).to.equal(30) // Sep
+    expect(DateUtils.daysInMonth(2017, 9)).to.equal(31) // Oct
+    expect(DateUtils.daysInMonth(2017, 10)).to.equal(30) // Nov
+    expect(DateUtils.daysInMonth(2017, 11)).to.equal(31) // Dec
   })
 })

--- a/test/unit/specs/Datepicker.spec.js
+++ b/test/unit/specs/Datepicker.spec.js
@@ -49,10 +49,10 @@ describe('Datepicker: mounted component', () => {
     const now = new Date()
     vm.setValue()
     expect(vm.selectedDate).to.equal(null)
-    const currDate = new Date(vm.currDate)
-    expect(currDate.getYear()).to.equal(now.getYear())
-    expect(currDate.getMonth()).to.equal(now.getMonth())
-    expect(currDate.getDate()).to.equal(1)
+    const pageDate = new Date(vm.pageDate)
+    expect(pageDate.getYear()).to.equal(now.getYear())
+    expect(pageDate.getMonth()).to.equal(now.getMonth())
+    expect(pageDate.getDate()).to.equal(1)
   })
 
   it('knows the selected year', () => {
@@ -106,21 +106,17 @@ describe('Datepicker.vue', () => {
     })
   })
 
-  it('should render correct contents', async () => {
-    await vm.$nextTick(() => {
-      expect(vm.$el.querySelectorAll('.vdp-datepicker').length).to.equal(1)
-      expect(vm.$el.querySelectorAll('input').length).to.equal(1)
-    })
+  it('should render correct contents', () => {
+    expect(vm.$el.querySelectorAll('input').length).to.equal(1)
+    expect(vm.$el.querySelectorAll('.vdp-datepicker__calendar').length).to.equal(3)
   })
 
-  it('should set currdate to be now', async () => {
-    await vm.$nextTick(() => {
-      const data = Datepicker.data()
-      const d = new Date(data.currDate)
-      expect(d.getFullYear()).to.equal(new Date().getFullYear())
-      expect(d.getMonth()).to.equal(new Date().getMonth())
-      expect(d.getDate()).to.equal(1)
-    })
+  it('should set pageDate to be now', () => {
+    const data = Datepicker.data()
+    const d = new Date(data.pageDate)
+    expect(d.getFullYear()).to.equal(new Date().getFullYear())
+    expect(d.getMonth()).to.equal(new Date().getMonth())
+    expect(d.getDate()).to.equal(1)
   })
 
   it('should open and close the calendar', () => {
@@ -146,21 +142,21 @@ describe('Datepicker.vue', () => {
   it('can select a day', () => {
     const date = new Date(2016, 9, 1)
     vm.selectDate({timestamp: date.getTime()})
-    expect(vm.currDate).to.equal(date.getTime())
+    expect(vm.pageDate).to.equal(date.getTime())
     expect(vm.showDayView).to.equal(false)
   })
 
   it('can select a month', () => {
     const date = new Date(2016, 9, 9)
     vm.selectMonth({timestamp: date.getTime()})
-    expect(vm.currDate).to.equal(date.getTime())
+    expect(vm.getPageMonth()).to.equal(9)
     expect(vm.showDayView).to.equal(true)
   })
 
   it('can select a year', () => {
     const date = new Date(2016, 9, 9)
     vm.selectYear({timestamp: date.getTime()})
-    expect(vm.currDate).to.equal(date.getTime())
+    expect(vm.getPageYear()).to.equal(2016)
     expect(vm.showMonthView).to.equal(true)
   })
 
@@ -168,61 +164,68 @@ describe('Datepicker.vue', () => {
     const date = new Date(2016, 9, 9)
     vm.selectDate({timestamp: date.getTime()})
     vm.nextMonth()
-    expect(vm.getMonth()).to.equal(10)
+    expect(vm.getPageMonth()).to.equal(10)
   })
 
   it('can set the next month correctly on the last day of a 31 day month', () => {
     const date = new Date(2017, 4, 31)
+    expect(date.getMonth()).to.equal(4)
     vm.selectDate({timestamp: date.getTime()})
-    // when click document to close the modal will run resetDefaultDate();
-    vm.resetDefaultDate()
+    expect(vm.getPageMonth()).to.equal(4)
+    expect(vm.getPageDate()).to.equal(1)
     vm.nextMonth()
-    expect(vm.getMonth()).to.equal(5)
+    expect(vm.getPageMonth()).to.equal(5)
   })
 
   it('can set the previous month', () => {
     const date = new Date(2016, 9, 9)
     vm.selectDate({timestamp: date.getTime()})
     vm.previousMonth()
-    expect(vm.getMonth()).to.equal(8)
+    expect(vm.getPageMonth()).to.equal(8)
     vm.previousMonth()
-    expect(vm.getMonth()).to.equal(7)
+    expect(vm.getPageMonth()).to.equal(7)
   })
 
   it('can set the next year', () => {
     const date = new Date(2016, 9, 9)
     vm.selectDate({timestamp: date.getTime()})
     vm.nextYear()
-    expect(vm.getYear()).to.equal(2017)
+    expect(vm.getPageYear()).to.equal(2017)
   })
 
   it('can set the previous year', () => {
     const date = new Date(2016, 9, 9)
     vm.selectDate({timestamp: date.getTime()})
     vm.previousYear()
-    expect(vm.getYear()).to.equal(2015)
+    expect(vm.getPageYear()).to.equal(2015)
   })
 
   it('can set the next decade', () => {
     const date = new Date(2016, 9, 9)
     vm.selectDate({timestamp: date.getTime()})
     vm.nextDecade()
-    expect(vm.getDecade()).to.equal('2020\'s')
+    expect(vm.getPageDecade()).to.equal('2020\'s')
   })
 
   it('can set the previous decade', () => {
     const date = new Date(2016, 9, 9)
     vm.selectDate({timestamp: date.getTime()})
     vm.previousDecade()
-    expect(vm.getDecade()).to.equal('2000\'s')
+    expect(vm.getPageDecade()).to.equal('2000\'s')
   })
 
-  it('sets the default date to the first of the month', () => {
+  it('should reset to default date', () => {
+    const date = new Date(2016, 9, 9)
+    vm.selectDate({timestamp: date.getTime()})
+    expect(vm.getPageMonth()).to.equal(9)
+    vm.nextMonth()
+    expect(vm.getPageMonth()).to.equal(10)
+    vm.resetDefaultDate()
+    expect(vm.getPageMonth()).to.equal(9)
     vm.clearDate()
     vm.resetDefaultDate()
-    expect(vm.selectedDate).to.be.null
-    const defaultDate = new Date(vm.getDefaultDate())
-    expect(defaultDate.getDate()).to.equal(1)
+    expect(vm.getPageYear()).to.equal(new Date().getFullYear())
+    expect(vm.getPageMonth()).to.equal(new Date().getMonth())
   })
 })
 
@@ -315,21 +318,6 @@ describe('Datepicker disabled dates', () => {
 })
 
 describe('Datepicker has disabled dates but can change dates', () => {
-  // beforeEach(() => {
-  //   vm = new Vue({
-  //     template: '<div><datepicker :inline="true" :disabled="disabled" :value="value" v-ref:component></datepicker></div>',
-  //     components: { Datepicker },
-  //     data () {
-  //       return {
-  //         disabled: {
-  //           to: new Date(2016, 8, 5),
-  //           from: new Date(2016, 10, 25)
-  //         }
-  //       }
-  //     }
-  //   }).$mount()
-  // })
-
   it('cant change month despite having a disabled month', () => {
     vm = getViewModel(Datepicker, {
       disabled: {
@@ -339,7 +327,7 @@ describe('Datepicker has disabled dates but can change dates', () => {
     })
     const newDate = new Date(2016, 9, 15)
     vm.setValue(newDate)
-    expect(vm.getMonth()).to.equal(9)
+    expect(vm.getPageMonth()).to.equal(9)
     expect(vm.previousMonth()).to.not.equal(false)
     expect(vm.nextMonth()).to.not.equal(false)
   })
@@ -486,12 +474,12 @@ describe('Datepicker with monday as first day of week', () => {
   })
 
   it('should have 6 blankDays when month starts from Sunday', () => {
-    vm.currDate = new Date(2016, 4, 1).getTime()
+    vm.pageDate = new Date(2016, 4, 1).getTime()
     expect(vm.blankDays).to.equal(6)
   })
 
   it('should have no blankDays when month starts from Monday', () => {
-    vm.currDate = new Date(2017, 4, 1).getTime()
+    vm.pageDate = new Date(2017, 4, 1).getTime()
     expect(vm.blankDays).to.equal(0)
   })
 })


### PR DESCRIPTION
This PR preserves local time in the Date object when a date is selected.
Hopefully this will prevent users in a timezones behind UTC getting the previous day.

Rename of internal property to hold the current page position.

Resolves #63, #98, #23, #202, #200, #118