### PR TITLE
Add a flag to show the full month name in head

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Inline always open version
 | name                  | String        |             | Input name property                      |
 | id                    | String        |             | Input id                                 |
 | format                | String        | dd MMM yyyy | Date formatting string                   |
+| full-month-name       | Boolean       | false       | To show the full month name              |
 | language              | String        | en          | Translation for days and months          |
 | disabled              | Object        |             | See below for configuration              |
 | placeholder           | String        |             | Input placeholder text                   |

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -103,6 +103,10 @@ export default {
       value: String,
       default: 'en'
     },
+    fullMonthName: {
+      value: Boolean,
+      default: false
+    },
     disabled: {
       type: Object
     },
@@ -204,7 +208,7 @@ export default {
     },
     currMonthName () {
       const d = new Date(this.pageDate)
-      return DateUtils.getMonthNameAbbr(d.getMonth(), this.translation.months.abbr)
+      return DateUtils.getMonthNameAbbr(d.getMonth(), this.fullMonthName ? this.translation.months.original : this.translation.months.abbr)
     },
     currYear () {
       const d = new Date(this.pageDate)


### PR DESCRIPTION
Added a flag to choose between `abbr` and `original` month format in the datepicker head. 