### PR TITLE
sv is for swedish, the Readme.txt is correct btw.

### DIFF
--- a/src/utils/DateLanguages.js
+++ b/src/utils/DateLanguages.js
@@ -208,7 +208,7 @@ export default {
       },
       'days': ['Вс', 'Пн', 'Вт', 'Ср', 'Чт', 'Пт', 'Сб']
     },
-    'se': {
+    'sv': {
       'language': 'Swedish',
       'months': {
         'original': ['Januari', 'Februari', 'Mars', 'April', 'Maj', 'Juni', 'Juli', 'Augusti', 'September', 'Oktober', 'November', 'December'],


### PR DESCRIPTION
We could also add sv-se, but default is sv then there is different type if swedish 