### PR TITLE
Watch initialView props to set initial-view

### DIFF
--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -194,6 +194,9 @@ export default {
   watch: {
     value (value) {
       this.setValue(value)
+    },
+    initialView () {
+      this.setInitialView()
     }
   },
   computed: {


### PR DESCRIPTION
If we have two inline calendar with v-if and v-else but different initial-view, the second inline calendar will have the same initial-view as the first. Therefore I add the watcher for initialView to set it.