### PR TITLE
Delegate date formatting

### DIFF
--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -96,7 +96,7 @@ export default {
       value: String
     },
     format: {
-      value: String,
+      value: [String, Function],
       default: 'dd MMM yyyy'
     },
     language: {
@@ -201,7 +201,10 @@ export default {
       if (!this.selectedDate) {
         return null
       }
-      return DateUtils.formatDate(new Date(this.selectedDate), this.format, this.translation)
+
+      return typeof this.format === 'function'
+        ? this.format(this.selectedDate)
+        : DateUtils.formatDate(new Date(this.selectedDate), this.format, this.translation)
     },
     translation () {
       return DateLanguages.translations[this.language]

--- a/test/unit/specs/Datepicker.spec.js
+++ b/test/unit/specs/Datepicker.spec.js
@@ -96,6 +96,14 @@ describe('Datepicker: mounted component', () => {
     vm.clearDate()
     expect(vm.selectedDate).to.equal(null)
   })
+
+  it('delegates date formating', () => {
+    const vm = getViewModel(Datepicker, {
+      value: new Date(2016, 1, 15),
+      format: () => '2016/1/15'
+    })
+    expect(vm.formattedValue).to.equal('2016/1/15')
+  })
 })
 
 describe('Datepicker.vue', () => {


### PR DESCRIPTION
Delegate date formatting. This will allow us to use moment, date-fns, globalize or any other library to format dates. 

This address issue #211

Usage:

```
<datepicker :format="formatter"></datepicker>

methods: {
  formatter(date) {
    return moment(date).format('MMMM Do YYYY, h:mm:ss a');
  }
}
```