### PR TITLE
Don't show calendar when `disabled-picker` is true

### DIFF
--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -331,6 +331,9 @@ export default {
      * @return {mixed} [description]
      */
     showCalendar () {
+      if (this.disabledPicker) {
+        return false;
+      }
       if (this.isInline) {
         return false
       }


### PR DESCRIPTION
When `calendar-button` is true, the calendar is shown even if ` disabled-picker` is set