### PR TITLE
Move babel-runtime to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,11 +29,11 @@
     "prepublish": "npm run build"
   },
   "dependencies": {
-    "babel-runtime": "^6.0.0"
   },
   "devDependencies": {
     "autoprefixer": "^6.7.2",
     "babel-core": "^6.22.1",
+    "babel-runtime": "^6.0.0",
     "babel-eslint": "^7.1.1",
     "babel-loader": "^6.2.10",
     "babel-plugin-istanbul": "^4.1.1",


### PR DESCRIPTION
Currently npm is saying there is 1 dependency due to babel-runtime package. This is not true as babel-runtime is devDependency. 