### PR TITLE
Emit event when a disabled date is selected

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ These events are emitted on actions in the datepicker
 | opened            |            | The picker is opened                 |
 | closed            |            | The picker is closed                 |
 | selected          | Date\|null | A date has been selected             |
-| selectedDisabled  | Date\|null | A disabled date has been selected    |
+| selectedDisabled  | Object     | A disabled date has been selected    |
 | input             | Date\|null | Input value has been modified        |
 | cleared           |            | Selected date has been cleared       |
 | changedMonth      | Object     | Month page has been changed          |

--- a/README.md
+++ b/README.md
@@ -89,16 +89,17 @@ Inline always open version
 
 These events are emitted on actions in the datepicker
 
-| Event         | Output     | Description                   |
-|---------------|------------|-------------------------------|
-| opened        |            | The picker is opened          |
-| closed        |            | The picker is closed          |
-| selected      | Date\|null | A date has been selected      |
-| input         | Date\|null | Input value has been modified |
-| cleared       |            | Selected date has been cleared|
-| changedMonth  | Object     | Month page has been changed   |
-| changedYear   | Object     | Year page has been changed    |
-| changedDecade | Object     | Decade page has been changed  |
+| Event             | Output     | Description                          |
+|-------------------|------------|--------------------------------------|
+| opened            |            | The picker is opened                 |
+| closed            |            | The picker is closed                 |
+| selected          | Date\|null | A date has been selected             |
+| selectedDisabled  | Object     | A disabled date has been selected    |
+| input             | Date\|null | Input value has been modified        |
+| cleared           |            | Selected date has been cleared       |
+| changedMonth      | Object     | Month page has been changed          |
+| changedYear       | Object     | Year page has been changed           |
+| changedDecade     | Object     | Decade page has been changed         |
 
 
 ## Date formatting

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ These events are emitted on actions in the datepicker
 | opened            |            | The picker is opened                 |
 | closed            |            | The picker is closed                 |
 | selected          | Date\|null | A date has been selected             |
-| selectedDisabled  | Object     | A disabled date has been selected    |
+| selectedDisabled  | Date\|null | A disabled date has been selected    |
 | input             | Date\|null | Input value has been modified        |
 | cleared           |            | Selected date has been cleared       |
 | changedMonth      | Object     | Month page has been changed          |

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -44,8 +44,8 @@
             </header>
             <div :class="isRtl ? 'flex-rtl' : ''">
               <span class="cell day-header" v-for="d in daysOfWeek" :key="d.timestamp">{{ d }}</span>
-              <span class="cell day blank" v-for="d in blankDays" :key="d.timestamp"></span><!--
-              --><span class="cell day"
+              <span class="cell day blank" v-for="d in blankDays" :key="d.timestamp"></span>
+              <span class="cell day"
                   v-for="day in days"
                   :key="day.timestamp"
                   track-by="timestamp"

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -44,8 +44,8 @@
             </header>
             <div :class="isRtl ? 'flex-rtl' : ''">
               <span class="cell day-header" v-for="d in daysOfWeek" :key="d.timestamp">{{ d }}</span>
-              <span class="cell day blank" v-for="d in blankDays" :key="d.timestamp"></span>
-              <span class="cell day"
+              <span class="cell day blank" v-for="d in blankDays" :key="d.timestamp"></span><!--
+              --><span class="cell day"
                   v-for="day in days"
                   :key="day.timestamp"
                   track-by="timestamp"

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -376,6 +376,7 @@ export default {
      */
     selectDate (day) {
       if (day.isDisabled) {
+        this.$emit('selectedDisabled', day)
         return false
       }
       this.setDate(day.timestamp)


### PR DESCRIPTION
When a disabled date is clicked, the `selectedDisabled` event will be emitted.

This functionality will be useful for displaying a reason why a date is not selectable.

Open to suggestions on the name of the event if you feel that `selectedDisabled` doesn't describe it well.