### PR TITLE
Allow setting minimum and maximum view

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,11 @@ Inline always open version
 | calendar-button       | Boolean         | false       | Show an icon that that can be clicked    |
 | calendar-button-icon  | String          |             | Use icon for button (ex: fa fa-calendar) |
 | bootstrapStyling      | Boolean         | false       | Output bootstrap styling classes         |
-| initial-view          | String          | 'day'       | If 'month' or 'year', open on that view  |
+| initial-view          | String          | minimumView | If set, open on that view                |
 | disabled-picker       | Boolean         | false       | If true, disable Datepicker on screen    |
 | required              | Boolean         | false       | Sets html required attribute on input    |
-| day-view-only         | Boolean         | false       | If true, month and year views won't show |
+| minimum-view          | String          | 'day'       | If set, lower-level views won't show     |
+| maximum-view          | String          | 'year'      | If set, higher-level views won't show    |
 
 ## Events
 

--- a/src/Demo.vue
+++ b/src/Demo.vue
@@ -107,7 +107,7 @@
       <div class="settings">
         <h5>Settings</h5>
         <select v-model="language">
-          <option :value="key" v-for="(language, key) in languages">{{ language.language }}</option>
+          <option :value="key" v-for="(language, key) in languages" :key="key">{{ language.language }}</option>
         </select>
       </div>
     </div>
@@ -123,23 +123,47 @@
       <h3>RTL datepicker</h3>
       <datepicker language="he"></datepicker>
       <code>
-          &lt;datepicker :inline="true"&gt;&lt;/datepicker&gt;
-      </code>
-    </div>
-
-    <div class="example">
-      <h3>Day view only RTL</h3>
-      <datepicker :day-view-only="true" language="he"></datepicker>
-      <code>
-        &lt;datepicker :day-view-only="true"&gt;&lt;/datepicker&gt;
+          &lt;datepicker  language="he"&gt;&lt;/datepicker&gt;
       </code>
     </div>
 
     <div class="example">
       <h3>Day view only</h3>
-      <datepicker :day-view-only="true"></datepicker>
+      <datepicker :minimumView="'day'" :maximumView="'day'"></datepicker>
       <code>
-        &lt;datepicker :day-view-only="true"&gt;&lt;/datepicker&gt;
+        &lt;datepicker :minimumView="'day'" :maximumView="'day'"&gt;&lt;/datepicker&gt;
+      </code>
+    </div>
+
+    <div class="example">
+      <h3>Day view only RTL</h3>
+      <datepicker :minimumView="'day'" :maximumView="'day'" language="he"></datepicker>
+      <code>
+        &lt;datepicker :minimumView="'day'" :maximumView="'day'" language="he"&gt;&lt;/datepicker&gt;
+      </code>
+    </div>
+
+    <div class="example">
+      <h3>Month view only</h3>
+      <datepicker :minimumView="'month'" :maximumView="'month'"></datepicker>
+      <code>
+        &lt;datepicker :minimumView="'month'" :maximumView="'month'"&gt;&lt;/datepicker&gt;
+      </code>
+    </div>
+
+    <div class="example">
+      <h3>Day and month view only</h3>
+      <datepicker :minimumView="'day'" :maximumView="'month'" :initialView="'month'"></datepicker>
+      <code>
+        &lt;datepicker :minimumView="'day'" :maximumView="'month'" :initialView="'month'"&gt;&lt;/datepicker&gt;
+      </code>
+    </div>
+
+    <div class="example">
+      <h3>Year and month view only</h3>
+      <datepicker :minimumView="'month'" :maximumView="'year'" :initialView="'year'"></datepicker>
+      <code>
+        &lt;datepicker :minimumView="'month'" :maximumView="'year'" :initialView="'year'"&gt;&lt;/datepicker&gt;
       </code>
     </div>
 

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -334,6 +334,9 @@ export default {
         return this.close()
       }
       this.setInitialView()
+      if (!this.isInline) {
+        this.$emit('opened')
+      }
     },
     setInitialView () {
       const initialView = this.computedInitialView
@@ -368,7 +371,6 @@ export default {
       this.close()
       this.showDayView = true
       if (!this.isInline) {
-        this.$emit('opened')
         document.addEventListener('click', this.clickOutside, false)
       }
     },

--- a/test/unit/specs/Datepicker.spec.js
+++ b/test/unit/specs/Datepicker.spec.js
@@ -616,6 +616,7 @@ describe('Datepicker with restricted views', () => {
     expect(vm.years[0].year).to.equal(vm.selectedDate.getFullYear())
     const inputDate = new Date(vm.months[0].timestamp)
     expect(inputDate.getMonth()).to.equal(vm.selectedDate.getMonth())
+    expect(vm.isOpen).to.equal(false)
   })
 
   it('should save and close when selecting on minimum-view "year"', () => {

--- a/test/unit/specs/Datepicker.spec.js
+++ b/test/unit/specs/Datepicker.spec.js
@@ -605,6 +605,29 @@ describe('Datepicker with restricted views', () => {
     expect(vm.computedInitialView).to.equal('month')
   })
 
+  it('should save and close when selecting on minimum-view "month"', () => {
+    vm = getViewModel(Datepicker, {
+      minimumView: 'month',
+      maximumView: 'year'
+    })
+    vm.selectYear(vm.years[0])
+    expect(vm.isOpen).to.equal(true)
+    vm.selectMonth(vm.months[0])
+    expect(vm.years[0].year).to.equal(vm.selectedDate.getFullYear())
+    const inputDate = new Date(vm.months[0].timestamp)
+    expect(inputDate.getMonth()).to.equal(vm.selectedDate.getMonth())
+  })
+
+  it('should save and close when selecting on minimum-view "year"', () => {
+    vm = getViewModel(Datepicker, {
+      minimumView: 'year',
+      maximumView: 'year'
+    })
+    vm.selectYear(vm.years[0])
+    expect(vm.isOpen).to.equal(false)
+    expect(vm.years[0].year).to.equal(vm.selectedDate.getFullYear())
+  })
+
   it('should only allow views in min-max range', () => {
     vm = getViewModel(Datepicker, {
       minimumView: 'day',

--- a/test/unit/specs/Datepicker.spec.js
+++ b/test/unit/specs/Datepicker.spec.js
@@ -567,7 +567,7 @@ describe('Datepicker with initial-view', () => {
   it('should open in Day view', () => {
     vm = getViewModel(Datepicker)
     vm.showCalendar()
-    expect(vm.initialView).to.equal('day')
+    expect(vm.computedInitialView).to.equal('day')
     expect(vm.showDayView).to.equal(true)
     expect(vm.showMonthView).to.equal(false)
     expect(vm.showYearView).to.equal(false)
@@ -578,7 +578,7 @@ describe('Datepicker with initial-view', () => {
       initialView: 'month'
     })
     vm.showCalendar()
-    expect(vm.initialView).to.equal('month')
+    expect(vm.computedInitialView).to.equal('month')
     expect(vm.showDayView).to.equal(false)
     expect(vm.showMonthView).to.equal(true)
     expect(vm.showYearView).to.equal(false)
@@ -589,41 +589,77 @@ describe('Datepicker with initial-view', () => {
       initialView: 'year'
     })
     vm.showCalendar()
-    expect(vm.initialView).to.equal('year')
+    expect(vm.computedInitialView).to.equal('year')
     expect(vm.showDayView).to.equal(false)
     expect(vm.showMonthView).to.equal(false)
     expect(vm.showYearView).to.equal(true)
   })
 })
 
-describe('Datepicker with day-view-only', () => {
-  beforeEach(() => {
+describe('Datepicker with restricted views', () => {
+  it('should default initialVicomputedInitialViewew to minimumView', () => {
     vm = getViewModel(Datepicker, {
-      dayViewOnly: true
+      minimumView: 'month',
+      maximumView: 'month'
+    })
+    expect(vm.computedInitialView).to.equal('month')
+  })
+
+  it('should only allow views in min-max range', () => {
+    vm = getViewModel(Datepicker, {
+      minimumView: 'day',
+      maximumView: 'month'
+    })
+    expect(vm.allowedToShowView('year')).to.equal(false)
+    expect(vm.allowedToShowView('day')).to.equal(true)
+    expect(vm.allowedToShowView('month')).to.equal(true)
+
+    vm = getViewModel(Datepicker, {
+      minimumView: 'month',
+      maximumView: 'month'
+    })
+    expect(vm.allowedToShowView('day')).to.equal(false)
+    expect(vm.allowedToShowView('year')).to.equal(false)
+    expect(vm.allowedToShowView('month')).to.equal(true)
+
+    vm = getViewModel(Datepicker, {
+      minimumView: 'day',
+      maximumView: 'year'
+    })
+    expect(vm.allowedToShowView('day')).to.equal(true)
+    expect(vm.allowedToShowView('year')).to.equal(true)
+    expect(vm.allowedToShowView('month')).to.equal(true)
+  })
+
+  it('should throw an error on disallowed initial views', () => {
+    vm = getViewModel(Datepicker, {
+      minimumView: 'day',
+      maximumView: 'month',
+      initialView: 'year'
+    })
+
+    expect(function () {
+      vm.setInitialView()
+    }).to.throw()
+  })
+
+  it('should not render unused views', () => {
+    vm = getViewModel(Datepicker, {
+      minimumView: 'day',
+      maximumView: 'day'
     })
     vm.showCalendar()
-  })
-
-  it('should open in Day view', () => {
-    expect(vm.initialView).to.equal('day')
-    expect(vm.showDayView).to.equal(true)
-    expect(vm.showMonthView).to.equal(false)
-    expect(vm.showYearView).to.equal(false)
-  })
-
-  it('should return false on showMonthCalendar', () => {
-    let func = vm.showMonthCalendar()
-    expect(func).to.equal(false)
-  })
-
-  it('should not open month view on showMonthCalendar', () => {
-    vm.showMonthCalendar()
-    expect(vm.showMonthView).to.equal(false)
-  })
-
-  it('should not render month and year views', () => {
     expect(vm.$el.querySelectorAll('.vdp-datepicker__calendar').length).to.equal(1)
     expect(vm.$el.querySelectorAll('.vdp-datepicker__calendar .cell.month').length).to.equal(0)
     expect(vm.$el.querySelectorAll('.vdp-datepicker__calendar .cell.year').length).to.equal(0)
+
+    vm = getViewModel(Datepicker, {
+      minimumView: 'month',
+      maximumView: 'year'
+    })
+    vm.showCalendar()
+    expect(vm.$el.querySelectorAll('.vdp-datepicker__calendar').length).to.equal(2)
+    expect(vm.$el.querySelectorAll('.vdp-datepicker__calendar .cell.day').length).to.equal(0)
+    expect(vm.$el.querySelectorAll('.vdp-datepicker__calendar .cell.year').length).to.not.equal(0)
   })
 })


### PR DESCRIPTION
These changes add the options `minimum-view` and `maximum-view`, and remove `day-view-only`. There's also a small fix to add a `:key` to the demo language select `v-for` loop.

Issue for this is #190.

Since day-view-only is getting removed, it will probably need a major version bump. If you do not want this, it wouldn't be hard to add it back in. That would result in duplicate functionality however.