### PR TITLE
added short delay before adding clickOutside listener

### DIFF
--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -386,26 +386,27 @@ export default {
 
       this.close()
       this.showDayView = true
-      if (!this.isInline) {
-        document.addEventListener('click', this.clickOutside, false)
-      }
+      this.addOutsideClickListener()
     },
     showMonthCalendar () {
       if (!this.allowedToShowView('month')) return false
 
       this.close()
       this.showMonthView = true
-      if (!this.isInline) {
-        document.addEventListener('click', this.clickOutside, false)
-      }
+      this.addOutsideClickListener()
     },
     showYearCalendar () {
       if (!this.allowedToShowView('year')) return false
 
       this.close()
       this.showYearView = true
+      this.addOutsideClickListener()
+    },
+    addOutsideClickListener () {
       if (!this.isInline) {
-        document.addEventListener('click', this.clickOutside, false)
+        setTimeout(() => {
+          document.addEventListener('click', this.clickOutside, false)
+        }, 100)
       }
     },
     setDate (timestamp) {


### PR DESCRIPTION
as described in https://github.com/charliekassel/vuejs-datepicker/issues/377

it isn't currently possible to open the calendar programatically because the code immediately closes any calendar that is opened from a button that's outside the Datepicker component. Adding this short delay resolves the problem

also added it as a wrapper function to prevent duplicate code