### PR TITLE
add full-month-name in months select panel

### DIFF
--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -279,7 +279,7 @@ export default {
       let dObj = new Date(d.getFullYear(), 0, d.getDate(), d.getHours(), d.getMinutes())
       for (let i = 0; i < 12; i++) {
         months.push({
-          month: DateUtils.getMonthName(i, this.translation.months.original),
+          month: DateUtils.getMonthName(i, this.fullMonthName ? this.translation.months.original : this.translation.months.abbr),
           timestamp: dObj.getTime(),
           isSelected: this.isSelectedMonth(dObj),
           isDisabled: this.isDisabledMonth(dObj)


### PR DESCRIPTION
We would see the month name in the month select panel is full name. This is not we want because it seems the full-month-name prop didn't work. And when in small devices, there would be a overflow with the full month name. So I made some modify.