### PR TITLE
Fixes SSR - Set the webpack target to node

### DIFF
--- a/build/webpack.prod.conf.js
+++ b/build/webpack.prod.conf.js
@@ -8,6 +8,7 @@ var env = process.env.NODE_ENV === 'testing'
   : config.build.env
 
 var webpackConfig = merge(baseWebpackConfig, {
+  target: 'node',
   module: {
     rules: utils.styleLoaders({
       sourceMap: config.build.productionSourceMap,


### PR DESCRIPTION
Fixes #147 

The build didn't work with SSR because it was built against `target: 'web'` which is the default one. Switching it with `target: 'node'` makes it work Server-side. Also [`vue-style-loader`](https://github.com/vuejs/vue-style-loader#server-side-rendering-support) requires the switch for component styles to be prerendered for use in Node.

I tested SSR against my nuxt project. Works fine.