### PR TITLE
Pass data date to emitted events changedYear/changedDecade

### DIFF
--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -536,7 +536,7 @@ export default {
       let date = this.pageDate
       date.setYear(date.getFullYear() + incrementBy)
       this.setPageDate(date)
-      this.$emit(emit)
+      this.$emit(emit, date)
     },
     previousYear () {
       if (!this.previousYearDisabled()) {


### PR DESCRIPTION
When clicking navigation arrows  in year and decade view is passed date to emitted events changedYear/changedDecade, just like in navigating month view.