### PR TITLE
Allow highlighting of disabled dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,8 +185,10 @@ var state = {
 ```
 
 ## Highlight Dates
-Dates can be highlighted (e.g. for marking an appointment) in a number of ways. Important: You can only highlight dates, that aren't disabled.
-Note: Both `to` and `from` properties are required to define a range of dates to highlight
+Dates can be highlighted (e.g. for marking an appointment) in a number of ways. Important:
+By default disabled dates are ignored, to highlight disabled dates set the `includeDisabled`
+property to `true`. Note: Both `to` and `from` properties are required to define a range of
+dates to highlight.
 
 ``` html
 <script>
@@ -210,7 +212,8 @@ var state = {
           if(date.getDate() % 4 == 0){
             return true
           }
-        }
+        },
+        includeDisabled: true // Highlight disabled dates
     }
 }
 </script>

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -951,6 +951,8 @@ $width = 300px
                 background #4bd
         &.highlighted
             background #cae5ed
+            &.disabled
+                color: #a3a3a3
         &.grey
             color #888
 

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -641,12 +641,12 @@ export default {
       return disabled
     },
     /**
-     * Whether a day is highlighted (only if it is not disabled already)
+     * Whether a day is highlighted (only if it is not disabled already except when highlighted.includeDisabled is true)
      * @param {Date}
      * @return {Boolean}
      */
     isHighlightedDate (date) {
-      if (this.isDisabledDate(date)) {
+      if (!(this.highlighted && this.highlighted.includeDisabled) && this.isDisabledDate(date)) {
         return false
       }
 

--- a/test/unit/specs/Datepicker.spec.js
+++ b/test/unit/specs/Datepicker.spec.js
@@ -498,6 +498,20 @@ describe('Datepicker highlight date', () => {
     expect(vm.isHighlightedDate(new Date(2016, 12, 5))).to.equal(false)
   })
 
+  it('should highlight a disabled date when explicitly configured to', () => {
+    vm = getViewModel(Datepicker, {
+      highlighted: {
+        to: new Date(2016, 12, 8),
+        from: new Date(2016, 12, 4),
+        includeDisabled: true
+      },
+      disabled: {
+        dates: [ new Date(2016, 12, 5) ]
+      }
+    })
+    expect(vm.isHighlightedDate(new Date(2016, 12, 5))).to.equal(true)
+  })
+
   it('should highlight a date before the to property', () => {
     expect(vm.isHighlightedDate(new Date(2016, 12, 7))).to.equal(true)
   })


### PR DESCRIPTION
This adds the `includeDisabled` option to `highlighted` which allows disabled dates to be highlighted.