### PR TITLE
add UTC full support

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Inline always open version
 | disabled                      | Boolean         | false       | If true, disable Datepicker on screen    |
 | required                      | Boolean         | false       | Sets html required attribute on input    |
 | typeable                      | Boolean         | false       | If true, allow the user to type the date |
+| use-utc                       | Boolean         | false       | use UTC for time calculations            |
 | open-date                     | Date\|String    |             | If set, open on that date                |
 | minimum-view                  | String          | 'day'       | If set, lower-level views won't show     |
 | maximum-view                  | String          | 'year'      | If set, higher-level views won't show    |
@@ -277,7 +278,7 @@ to show some custom text:
 
 #### afterDateInput
 
-To implement some custom styling (for instance to add an animated placeholder) on DateInput, you might need to add elements as DateInput siblings. Slot named 
+To implement some custom styling (for instance to add an animated placeholder) on DateInput, you might need to add elements as DateInput siblings. Slot named
 `afterDateInput` allows you to do that:
 
 ``` html
@@ -287,7 +288,7 @@ To implement some custom styling (for instance to add an animated placeholder) o
   </span>
 </datepicker>
 ```
- 
+
 
 ## Translations
 

--- a/src/components/DateInput.vue
+++ b/src/components/DateInput.vue
@@ -34,7 +34,7 @@
   </div>
 </template>
 <script>
-import DateUtils from '../utils/DateUtils'
+import { makeDateUtils } from '../utils/DateUtils'
 export default {
   props: {
     selectedDate: Date,
@@ -60,9 +60,11 @@ export default {
     useUtc: Boolean
   },
   data () {
+    const constructedDateUtils = makeDateUtils(this.useUtc)
     return {
       input: null,
-      typedDate: false
+      typedDate: false,
+      utils: constructedDateUtils
     }
   },
   computed: {
@@ -75,7 +77,7 @@ export default {
       }
       return typeof this.format === 'function'
         ? this.format(this.selectedDate)
-        : DateUtils.formatDate(new Date(this.selectedDate), this.format, this.translation, this.useUtc)
+        : this.utils.formatDate(new Date(this.selectedDate), this.format, this.translation)
     },
 
     computedInputClass () {

--- a/src/components/DateInput.vue
+++ b/src/components/DateInput.vue
@@ -35,7 +35,6 @@
 </template>
 <script>
 import DateUtils from '../utils/DateUtils'
-
 export default {
   props: {
     selectedDate: Date,
@@ -57,7 +56,8 @@ export default {
     disabled: Boolean,
     required: Boolean,
     typeable: Boolean,
-    bootstrapStyling: Boolean
+    bootstrapStyling: Boolean,
+    useUtc: Boolean
   },
   data () {
     return {
@@ -75,7 +75,7 @@ export default {
       }
       return typeof this.format === 'function'
         ? this.format(this.selectedDate)
-        : DateUtils.formatDate(new Date(this.selectedDate), this.format, this.translation)
+        : DateUtils.formatDate(new Date(this.selectedDate), this.format, this.translation, this.useUtc)
     },
 
     computedInputClass () {

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -99,7 +99,7 @@ import DateInput from './DateInput.vue'
 import PickerDay from './PickerDay.vue'
 import PickerMonth from './PickerMonth.vue'
 import PickerYear from './PickerYear.vue'
-import DateUtils from '../utils/DateUtils'
+import { makeDateUtils } from '../utils/DateUtils'
 export default {
   components: {
     DateInput,
@@ -161,7 +161,8 @@ export default {
   },
   data () {
     const startDate = this.openDate ? new Date(this.openDate) : new Date()
-    const pageTimestamp = DateUtils.setDate(startDate, 1, this.useUtc)
+    const constructedDateUtils = makeDateUtils(this.useUtc)
+    const pageTimestamp = constructedDateUtils.setDate(startDate, 1)
     return {
       /*
        * Vue cannot observe changes to a Date Object so date must be stored as a timestamp
@@ -185,7 +186,8 @@ export default {
        * Positioning
        */
       calendarHeight: 0,
-      resetTypedDate: new Date()
+      resetTypedDate: new Date(),
+      utils: constructedDateUtils
     }
   },
   watch: {
@@ -412,7 +414,7 @@ export default {
           date = new Date()
         }
       }
-      this.pageTimestamp = DateUtils.setDate(new Date(date), 1, this.useUtc)
+      this.pageTimestamp = this.utils.setDate(new Date(date), 1)
     },
     /**
      * Set the date from a typedDate event

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -21,6 +21,7 @@
       :disabled="disabled"
       :required="required"
       :bootstrapStyling="bootstrapStyling"
+      :use-utc="useUtc"
       @showCalendar="showCalendar"
       @closeCalendar="close"
       @typedDate="setTypedDate"
@@ -46,6 +47,7 @@
       :isRtl="isRtl"
       :mondayFirst="mondayFirst"
       :dayCellContent="dayCellContent"
+      :use-utc="useUtc"
       @changedMonth="setPageDate"
       @selectDate="selectDate"
       @showMonthCalendar="showMonthCalendar"
@@ -65,6 +67,7 @@
       :calendarStyle="calendarStyle"
       :translation="translation"
       :isRtl="isRtl"
+      :use-utc="useUtc"
       @selectMonth="selectMonth"
       @showYearCalendar="showYearCalendar"
       @changedYear="setPageDate">
@@ -83,6 +86,7 @@
       :calendarStyle="calendarStyle"
       :translation="translation"
       :isRtl="isRtl"
+      :use-utc="useUtc"
       @selectYear="selectYear"
       @changedDecade="setPageDate">
       <slot name="beforeCalendarHeader" slot="beforeCalendarHeader"></slot>
@@ -95,6 +99,7 @@ import DateInput from './DateInput.vue'
 import PickerDay from './PickerDay.vue'
 import PickerMonth from './PickerMonth.vue'
 import PickerYear from './PickerYear.vue'
+import DateUtils from '../utils/DateUtils'
 export default {
   components: {
     DateInput,
@@ -144,6 +149,7 @@ export default {
     disabled: Boolean,
     required: Boolean,
     typeable: Boolean,
+    useUtc: Boolean,
     minimumView: {
       type: String,
       default: 'day'
@@ -155,13 +161,14 @@ export default {
   },
   data () {
     const startDate = this.openDate ? new Date(this.openDate) : new Date()
+    const pageTimestamp = DateUtils.setDate(startDate, 1, this.useUtc)
     return {
       /*
        * Vue cannot observe changes to a Date Object so date must be stored as a timestamp
        * This represents the first day of the current viewing month
        * {Number}
        */
-      pageTimestamp: startDate.setDate(1),
+      pageTimestamp,
       /*
        * Selected Date
        * {Date}
@@ -405,7 +412,7 @@ export default {
           date = new Date()
         }
       }
-      this.pageTimestamp = (new Date(date)).setDate(1)
+      this.pageTimestamp = DateUtils.setDate(new Date(date), 1, this.useUtc)
     },
     /**
      * Set the date from a typedDate event

--- a/src/components/PickerDay.vue
+++ b/src/components/PickerDay.vue
@@ -27,7 +27,7 @@
   </div>
 </template>
 <script>
-import DateUtils from '../utils/DateUtils'
+import { makeDateUtils } from '../utils/DateUtils'
 export default {
   props: {
     showDayView: Boolean,
@@ -48,6 +48,12 @@ export default {
     isRtl: Boolean,
     mondayFirst: Boolean,
     useUtc: Boolean
+  },
+  data () {
+    const constructedDateUtils = makeDateUtils(this.useUtc)
+    return {
+      utils: constructedDateUtils
+    }
   },
   computed: {
     /**
@@ -73,9 +79,9 @@ export default {
         new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1)) :
         new Date(d.getFullYear(), d.getMonth(), 1, d.getHours(), d.getMinutes())
       if (this.mondayFirst) {
-        return DateUtils.getDay(dObj, this.useUtc) > 0 ? DateUtils.getDay(dObj, this.useUtc) - 1 : 6
+        return this.utils.getDay(dObj) > 0 ? this.utils.getDay(dObj) - 1 : 6
       }
-      return DateUtils.getDay(dObj, this.useUtc)
+      return this.utils.getDay(dObj)
     },
     /**
      * @return {Object[]}
@@ -87,22 +93,22 @@ export default {
       let dObj = this.useUtc ?
         new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1)) :
         new Date(d.getFullYear(), d.getMonth(), 1, d.getHours(), d.getMinutes())
-      let daysInMonth = DateUtils.daysInMonth(DateUtils.getFullYear(dObj, this.useUtc), DateUtils.getMonth(dObj, this.useUtc))
+      let daysInMonth = this.utils.daysInMonth(this.utils.getFullYear(dObj), this.utils.getMonth(dObj))
       for (let i = 0; i < daysInMonth; i++) {
         days.push({
-          date: DateUtils.getDate(dObj, this.useUtc),
+          date: this.utils.getDate(dObj),
           timestamp: dObj.getTime(),
           isSelected: this.isSelectedDate(dObj),
           isDisabled: this.isDisabledDate(dObj),
           isHighlighted: this.isHighlightedDate(dObj),
           isHighlightStart: this.isHighlightStart(dObj),
           isHighlightEnd: this.isHighlightEnd(dObj),
-          isToday: DateUtils.compareDates(dObj, new Date(), this.useUtc),
-          isWeekend: DateUtils.getDay(dObj, this.useUtc) === 0 || DateUtils.getDay(dObj, this.useUtc) === 6,
-          isSaturday: DateUtils.getDay(dObj, this.useUtc) === 6,
-          isSunday: DateUtils.getDay(dObj, this.useUtc) === 0
+          isToday: this.utils.compareDates(dObj, new Date()),
+          isWeekend: this.utils.getDay(dObj) === 0 || this.utils.getDay(dObj) === 6,
+          isSaturday: this.utils.getDay(dObj) === 6,
+          isSunday: this.utils.getDay(dObj) === 0
         })
-        DateUtils.setDate(dObj, DateUtils.getDate(dObj, this.useUtc) + 1, this.useUtc)
+        this.utils.setDate(dObj, this.utils.getDate(dObj) + 1)
       }
       return days
     },
@@ -112,7 +118,7 @@ export default {
      */
     currMonthName () {
       const monthName = this.fullMonthName ? this.translation.months : this.translation.monthsAbbr
-      return DateUtils.getMonthNameAbbr(DateUtils.getMonth(this.pageDate, this.useUtc), monthName, this.useUtc)
+      return this.utils.getMonthNameAbbr(this.utils.getMonth(this.pageDate), monthName)
     },
     /**
      * Gets the name of the year that current page is on
@@ -120,7 +126,7 @@ export default {
      */
     currYearName () {
       const yearSuffix = this.translation.yearSuffix
-      return `${DateUtils.getFullYear(this.pageDate, this.useUtc)}${yearSuffix}`
+      return `${this.utils.getFullYear(this.pageDate)}${yearSuffix}`
     },
     /**
      * Is this translation using year/month/day format?
@@ -160,7 +166,7 @@ export default {
      * @return {Number}
      */
     getPageMonth () {
-      return DateUtils.getMonth(this.pageDate, this.useUtc)
+      return this.utils.getMonth(this.pageDate)
     },
     /**
      * Emit an event to show the month picker
@@ -174,7 +180,7 @@ export default {
      */
     changeMonth (incrementBy) {
       let date = this.pageDate
-      DateUtils.setMonth(date, DateUtils.getMonth(date, this.useUtc) + incrementBy, this.useUtc)
+      this.utils.setMonth(date, this.utils.getMonth(date) + incrementBy)
       this.$emit('changedMonth', date)
     },
     /**
@@ -194,8 +200,8 @@ export default {
         return false
       }
       let d = this.pageDate
-      return DateUtils.getMonth(this.disabledDates.to, this.useUtc) >= DateUtils.getMonth(d, this.useUtc) &&
-        DateUtils.getFullYear(this.disabledDates.to, this.useUtc) >= DateUtils.getFullYear(d, this.useUtc)
+      return this.utils.getMonth(this.disabledDates.to) >= this.utils.getMonth(d) &&
+        this.utils.getFullYear(this.disabledDates.to) >= this.utils.getFullYear(d)
     },
     /**
      * Increment the current page month
@@ -214,8 +220,8 @@ export default {
         return false
       }
       let d = this.pageDate
-      return DateUtils.getMonth(this.disabledDates.from, this.useUtc) <= DateUtils.getMonth(d, this.useUtc) &&
-        DateUtils.getFullYear(this.disabledDates.from, this.useUtc) <= DateUtils.getFullYear(d, this.useUtc)
+      return this.utils.getMonth(this.disabledDates.from) <= this.utils.getMonth(d) &&
+        this.utils.getFullYear(this.disabledDates.from) <= this.utils.getFullYear(d)
     },
     /**
      * Whether a day is selected
@@ -223,7 +229,7 @@ export default {
      * @return {Boolean}
      */
     isSelectedDate (dObj) {
-      return this.selectedDate && DateUtils.compareDates(this.selectedDate, dObj, this.useUtc)
+      return this.selectedDate && this.utils.compareDates(this.selectedDate, dObj)
     },
     /**
      * Whether a day is disabled
@@ -239,7 +245,7 @@ export default {
 
       if (typeof this.disabledDates.dates !== 'undefined') {
         this.disabledDates.dates.forEach((d) => {
-          if (DateUtils.compareDates(date, d, this.useUtc)) {
+          if (this.utils.compareDates(date, d)) {
             disabledDates = true
             return true
           }
@@ -261,10 +267,10 @@ export default {
           }
         })
       }
-      if (typeof this.disabledDates.days !== 'undefined' && this.disabledDates.days.indexOf(DateUtils.getDay(date, this.useUtc)) !== -1) {
+      if (typeof this.disabledDates.days !== 'undefined' && this.disabledDates.days.indexOf(this.utils.getDay(date)) !== -1) {
         disabledDates = true
       }
-      if (typeof this.disabledDates.daysOfMonth !== 'undefined' && this.disabledDates.daysOfMonth.indexOf(DateUtils.getDate(date, this.useUtc)) !== -1) {
+      if (typeof this.disabledDates.daysOfMonth !== 'undefined' && this.disabledDates.daysOfMonth.indexOf(this.utils.getDate(date)) !== -1) {
         disabledDates = true
       }
       if (typeof this.disabledDates.customPredictor === 'function' && this.disabledDates.customPredictor(date)) {
@@ -290,7 +296,7 @@ export default {
 
       if (typeof this.highlighted.dates !== 'undefined') {
         this.highlighted.dates.forEach((d) => {
-          if (DateUtils.compareDates(date, d, this.useUtc)) {
+          if (this.utils.compareDates(date, d)) {
             highlighted = true
             return true
           }
@@ -301,11 +307,11 @@ export default {
         highlighted = date >= this.highlighted.from && date <= this.highlighted.to
       }
 
-      if (typeof this.highlighted.days !== 'undefined' && this.highlighted.days.indexOf(DateUtils.getDay(date, this.useUtc)) !== -1) {
+      if (typeof this.highlighted.days !== 'undefined' && this.highlighted.days.indexOf(this.utils.getDay(date)) !== -1) {
         highlighted = true
       }
 
-      if (typeof this.highlighted.daysOfMonth !== 'undefined' && this.highlighted.daysOfMonth.indexOf(DateUtils.getDate(date, this.useUtc)) !== -1) {
+      if (typeof this.highlighted.daysOfMonth !== 'undefined' && this.highlighted.daysOfMonth.indexOf(this.utils.getDate(date)) !== -1) {
         highlighted = true
       }
 
@@ -337,9 +343,9 @@ export default {
     isHighlightStart (date) {
       return this.isHighlightedDate(date) &&
         (this.highlighted.from instanceof Date) &&
-        (DateUtils.getFullYear(this.highlighted.from, this.useUtc) === DateUtils.getFullYear(date, this.useUtc)) &&
-        (DateUtils.getMonth(this.highlighted.from, this.useUtc) === DateUtils.getMonth(date, this.useUtc)) &&
-        (DateUtils.getDate(this.highlighted.from, this.useUtc) === DateUtils.getDate(date, this.useUtc))
+        (this.utils.getFullYear(this.highlighted.from) === this.utils.getFullYear(date)) &&
+        (this.utils.getMonth(this.highlighted.from) === this.utils.getMonth(date)) &&
+        (this.utils.getDate(this.highlighted.from) === this.utils.getDate(date))
     },
     /**
      * Whether a day is highlighted and it is the first date
@@ -350,9 +356,9 @@ export default {
     isHighlightEnd (date) {
       return this.isHighlightedDate(date) &&
         (this.highlighted.to instanceof Date) &&
-        (DateUtils.getFullYear(this.highlighted.to, this.useUtc) === DateUtils.getFullYear(date, this.useUtc)) &&
-        (DateUtils.getMonth(this.highlighted.to, this.useUtc) === DateUtils.getMonth(date, this.useUtc)) &&
-        (DateUtils.getDate(this.highlighted.to, this.useUtc) === DateUtils.getDate(date, this.useUtc))
+        (this.utils.getFullYear(this.highlighted.to) === this.utils.getFullYear(date)) &&
+        (this.utils.getMonth(this.highlighted.to) === this.utils.getMonth(date)) &&
+        (this.utils.getDate(this.highlighted.to) === this.utils.getDate(date))
     },
     /**
      * Helper

--- a/src/components/PickerDay.vue
+++ b/src/components/PickerDay.vue
@@ -75,9 +75,9 @@ export default {
      */
     blankDays () {
       const d = this.pageDate
-      let dObj = this.useUtc ?
-        new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1)) :
-        new Date(d.getFullYear(), d.getMonth(), 1, d.getHours(), d.getMinutes())
+      let dObj = this.useUtc
+        ? new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1))
+        : new Date(d.getFullYear(), d.getMonth(), 1, d.getHours(), d.getMinutes())
       if (this.mondayFirst) {
         return this.utils.getDay(dObj) > 0 ? this.utils.getDay(dObj) - 1 : 6
       }
@@ -90,9 +90,9 @@ export default {
       const d = this.pageDate
       let days = []
       // set up a new date object to the beginning of the current 'page'
-      let dObj = this.useUtc ?
-        new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1)) :
-        new Date(d.getFullYear(), d.getMonth(), 1, d.getHours(), d.getMinutes())
+      let dObj = this.useUtc
+        ? new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1))
+        : new Date(d.getFullYear(), d.getMonth(), 1, d.getHours(), d.getMinutes())
       let daysInMonth = this.utils.daysInMonth(this.utils.getFullYear(dObj), this.utils.getMonth(dObj))
       for (let i = 0; i < daysInMonth; i++) {
         days.push({

--- a/src/components/PickerMonth.vue
+++ b/src/components/PickerMonth.vue
@@ -20,7 +20,7 @@
   </div>
 </template>
 <script>
-import DateUtils from '../utils/DateUtils'
+import { makeDateUtils } from '../utils/DateUtils'
 export default {
   props: {
     showMonthView: Boolean,
@@ -35,6 +35,12 @@ export default {
     allowedToShowView: Function,
     useUtc: Boolean
   },
+  data () {
+    const constructedDateUtils = makeDateUtils(this.useUtc)
+    return {
+      utils: constructedDateUtils
+    }
+  },
   computed: {
     months () {
       const d = this.pageDate
@@ -45,12 +51,12 @@ export default {
         new Date(d.getFullYear(), 0, d.getDate(), d.getHours(), d.getMinutes())
       for (let i = 0; i < 12; i++) {
         months.push({
-          month: DateUtils.getMonthName(i, this.translation.months, this.useUtc),
+          month: this.utils.getMonthName(i, this.translation.months),
           timestamp: dObj.getTime(),
           isSelected: this.isSelectedMonth(dObj),
           isDisabled: this.isDisabledMonth(dObj)
         })
-        DateUtils.setMonth(dObj, DateUtils.getMonth(dObj, this.useUtc) + 1, this.useUtc)
+        this.utils.setMonth(dObj, this.utils.getMonth(dObj) + 1)
       }
       return months
     },
@@ -60,7 +66,7 @@ export default {
      */
     pageYearName () {
       const yearSuffix = this.translation.yearSuffix
-      return `${DateUtils.getFullYear(this.pageDate, this.useUtc)}${yearSuffix}`
+      return `${this.utils.getFullYear(this.pageDate)}${yearSuffix}`
     },
     /**
      * Is the left hand navigation disabled
@@ -98,7 +104,7 @@ export default {
      */
     changeYear (incrementBy) {
       let date = this.pageDate
-      DateUtils.setFullYear(date, DateUtils.getFullYear(date, this.useUtc) + incrementBy, this.useUtc)
+      this.utils.setFullYear(date, this.utils.getFullYear(date) + incrementBy)
       this.$emit('changedYear', date)
     },
     /**
@@ -117,7 +123,7 @@ export default {
       if (!this.disabledDates || !this.disabledDates.to) {
         return false
       }
-      return DateUtils.getFullYear(this.disabledDates.to, this.useUtc) >= DateUtils.getFullYear(this.pageDate, this.useUtc)
+      return this.utils.getFullYear(this.disabledDates.to) >= this.utils.getFullYear(this.pageDate)
     },
     /**
      * Increments the year
@@ -135,7 +141,7 @@ export default {
       if (!this.disabledDates || !this.disabledDates.from) {
         return false
       }
-      return DateUtils.getFullYear(this.disabledDates.from, this.useUtc) <= DateUtils.getFullYear(this.pageDate, this.useUtc)
+      return this.utils.getFullYear(this.disabledDates.from) <= this.utils.getFullYear(this.pageDate)
     },
     /**
      * Emits an event that shows the year calendar
@@ -150,8 +156,8 @@ export default {
      */
     isSelectedMonth (date) {
       return (this.selectedDate &&
-        DateUtils.getFullYear(this.selectedDate, this.useUtc) === DateUtils.getFullYear(date, this.useUtc) &&
-        DateUtils.getMonth(this.selectedDate, this.useUtc) === DateUtils.getMonth(date, this.useUtc))
+        this.utils.getFullYear(this.selectedDate) === this.utils.getFullYear(date) &&
+        this.utils.getMonth(this.selectedDate) === this.utils.getMonth(date))
     },
     /**
      * Whether a month is disabled
@@ -167,8 +173,8 @@ export default {
 
       if (typeof this.disabledDates.to !== 'undefined' && this.disabledDates.to) {
         if (
-          (DateUtils.getMonth(date, this.useUtc) < DateUtils.getMonth(this.disabledDates.to, this.useUtc) && DateUtils.getFullYear(date, this.useUtc) <= DateUtils.getFullYear(this.disabledDates.to, this.useUtc)) ||
-          DateUtils.getFullYear(date, this.useUtc) < DateUtils.getFullYear(this.disabledDates.to, this.useUtc)
+          (this.utils.getMonth(date) < this.utils.getMonth(this.disabledDates.to) && this.utils.getFullYear(date) <= this.utils.getFullYear(this.disabledDates.to)) ||
+          this.utils.getFullYear(date) < this.utils.getFullYear(this.disabledDates.to)
         ) {
           disabledDates = true
         }
@@ -176,8 +182,8 @@ export default {
       if (typeof this.disabledDates.from !== 'undefined' && this.disabledDates.from) {
         if (
           this.disabledDates.from &&
-          (DateUtils.getMonth(date, this.useUtc) > DateUtils.getMonth(this.disabledDates.from, this.useUtc) && DateUtils.getFullYear(date, this.useUtc) >= DateUtils.getFullYear(this.disabledDates.from, this.useUtc)) ||
-          DateUtils.getFullYear(date, this.useUtc) > DateUtils.getFullYear(this.disabledDates.from, this.useUtc)
+          (this.utils.getMonth(date) > this.utils.getMonth(this.disabledDates.from) && this.utils.getFullYear(date) >= this.utils.getFullYear(this.disabledDates.from)) ||
+          this.utils.getFullYear(date) > this.utils.getFullYear(this.disabledDates.from)
         ) {
           disabledDates = true
         }

--- a/src/components/PickerMonth.vue
+++ b/src/components/PickerMonth.vue
@@ -32,22 +32,25 @@ export default {
     calendarStyle: Object,
     translation: Object,
     isRtl: Boolean,
-    allowedToShowView: Function
+    allowedToShowView: Function,
+    useUtc: Boolean
   },
   computed: {
     months () {
       const d = this.pageDate
       let months = []
       // set up a new date object to the beginning of the current 'page'
-      let dObj = new Date(d.getFullYear(), 0, d.getDate(), d.getHours(), d.getMinutes())
+      let dObj = this.useUtc ?
+        new Date(Date.UTC(d.getUTCFullYear(), 0, d.getUTCDate())) :
+        new Date(d.getFullYear(), 0, d.getDate(), d.getHours(), d.getMinutes())
       for (let i = 0; i < 12; i++) {
         months.push({
-          month: DateUtils.getMonthName(i, this.translation.months),
+          month: DateUtils.getMonthName(i, this.translation.months, this.useUtc),
           timestamp: dObj.getTime(),
           isSelected: this.isSelectedMonth(dObj),
           isDisabled: this.isDisabledMonth(dObj)
         })
-        dObj.setMonth(dObj.getMonth() + 1)
+        DateUtils.setMonth(dObj, DateUtils.getMonth(dObj, this.useUtc) + 1, this.useUtc)
       }
       return months
     },
@@ -57,7 +60,7 @@ export default {
      */
     pageYearName () {
       const yearSuffix = this.translation.yearSuffix
-      return `${this.pageDate.getFullYear()}${yearSuffix}`
+      return `${DateUtils.getFullYear(this.pageDate, this.useUtc)}${yearSuffix}`
     },
     /**
      * Is the left hand navigation disabled
@@ -95,7 +98,7 @@ export default {
      */
     changeYear (incrementBy) {
       let date = this.pageDate
-      date.setYear(date.getFullYear() + incrementBy)
+      DateUtils.setFullYear(date, DateUtils.getFullYear(date, this.useUtc) + incrementBy, this.useUtc)
       this.$emit('changedYear', date)
     },
     /**
@@ -114,7 +117,7 @@ export default {
       if (!this.disabledDates || !this.disabledDates.to) {
         return false
       }
-      return this.disabledDates.to.getFullYear() >= this.pageDate.getFullYear()
+      return DateUtils.getFullYear(this.disabledDates.to, this.useUtc) >= DateUtils.getFullYear(this.pageDate, this.useUtc)
     },
     /**
      * Increments the year
@@ -132,7 +135,7 @@ export default {
       if (!this.disabledDates || !this.disabledDates.from) {
         return false
       }
-      return this.disabledDates.from.getFullYear() <= this.pageDate.getFullYear()
+      return DateUtils.getFullYear(this.disabledDates.from, this.useUtc) <= DateUtils.getFullYear(this.pageDate, this.useUtc)
     },
     /**
      * Emits an event that shows the year calendar
@@ -147,8 +150,8 @@ export default {
      */
     isSelectedMonth (date) {
       return (this.selectedDate &&
-        this.selectedDate.getFullYear() === date.getFullYear() &&
-        this.selectedDate.getMonth() === date.getMonth())
+        DateUtils.getFullYear(this.selectedDate, this.useUtc) === DateUtils.getFullYear(date, this.useUtc) &&
+        DateUtils.getMonth(this.selectedDate, this.useUtc) === DateUtils.getMonth(date, this.useUtc))
     },
     /**
      * Whether a month is disabled
@@ -164,8 +167,8 @@ export default {
 
       if (typeof this.disabledDates.to !== 'undefined' && this.disabledDates.to) {
         if (
-          (date.getMonth() < this.disabledDates.to.getMonth() && date.getFullYear() <= this.disabledDates.to.getFullYear()) ||
-          date.getFullYear() < this.disabledDates.to.getFullYear()
+          (DateUtils.getMonth(date, this.useUtc) < DateUtils.getMonth(this.disabledDates.to, this.useUtc) && DateUtils.getFullYear(date, this.useUtc) <= DateUtils.getFullYear(this.disabledDates.to, this.useUtc)) ||
+          DateUtils.getFullYear(date, this.useUtc) < DateUtils.getFullYear(this.disabledDates.to, this.useUtc)
         ) {
           disabledDates = true
         }
@@ -173,8 +176,8 @@ export default {
       if (typeof this.disabledDates.from !== 'undefined' && this.disabledDates.from) {
         if (
           this.disabledDates.from &&
-          (date.getMonth() > this.disabledDates.from.getMonth() && date.getFullYear() >= this.disabledDates.from.getFullYear()) ||
-          date.getFullYear() > this.disabledDates.from.getFullYear()
+          (DateUtils.getMonth(date, this.useUtc) > DateUtils.getMonth(this.disabledDates.from, this.useUtc) && DateUtils.getFullYear(date, this.useUtc) >= DateUtils.getFullYear(this.disabledDates.from, this.useUtc)) ||
+          DateUtils.getFullYear(date, this.useUtc) > DateUtils.getFullYear(this.disabledDates.from, this.useUtc)
         ) {
           disabledDates = true
         }

--- a/src/components/PickerMonth.vue
+++ b/src/components/PickerMonth.vue
@@ -46,9 +46,9 @@ export default {
       const d = this.pageDate
       let months = []
       // set up a new date object to the beginning of the current 'page'
-      let dObj = this.useUtc ?
-        new Date(Date.UTC(d.getUTCFullYear(), 0, d.getUTCDate())) :
-        new Date(d.getFullYear(), 0, d.getDate(), d.getHours(), d.getMinutes())
+      let dObj = this.useUtc
+        ? new Date(Date.UTC(d.getUTCFullYear(), 0, d.getUTCDate()))
+        : new Date(d.getFullYear(), 0, d.getDate(), d.getHours(), d.getMinutes())
       for (let i = 0; i < 12; i++) {
         months.push({
           month: this.utils.getMonthName(i, this.translation.months),

--- a/src/components/PickerYear.vue
+++ b/src/components/PickerYear.vue
@@ -21,6 +21,7 @@
   </div>
 </template>
 <script>
+import DateUtils from '../utils/DateUtils'
 export default {
   props: {
     showYearView: Boolean,
@@ -33,22 +34,25 @@ export default {
     calendarStyle: Object,
     translation: Object,
     isRtl: Boolean,
-    allowedToShowView: Function
+    allowedToShowView: Function,
+    useUtc: Boolean
   },
   computed: {
     years () {
       const d = this.pageDate
       let years = []
-      // set up a new date object to the beginning of the current 'page'
-      let dObj = new Date(Math.floor(d.getFullYear() / 10) * 10, d.getMonth(), d.getDate(), d.getHours(), d.getMinutes())
+      // set up a new date object to the beginning of the current 'page'7
+      let dObj = this.useUtc ?
+        new Date(Date.UTC(Math.floor(d.getUTCFullYear() / 10) * 10, d.getUTCMonth(), d.getUTCDate())) :
+        new Date(Math.floor(d.getFullYear() / 10) * 10, d.getMonth(), d.getDate(), d.getHours(), d.getMinutes())
       for (let i = 0; i < 10; i++) {
         years.push({
-          year: dObj.getFullYear(),
+          year: DateUtils.getFullYear(dObj, this.useUtc),
           timestamp: dObj.getTime(),
           isSelected: this.isSelectedYear(dObj),
           isDisabled: this.isDisabledYear(dObj)
         })
-        dObj.setFullYear(dObj.getFullYear() + 1)
+        DateUtils.setFullYear(dObj, DateUtils.getFullYear(dObj, this.useUtc) + 1, this.useUtc)
       }
       return years
     },
@@ -56,7 +60,7 @@ export default {
      * @return {String}
      */
     getPageDecade () {
-      const decadeStart = Math.floor(this.pageDate.getFullYear() / 10) * 10
+      const decadeStart = Math.floor(DateUtils.getFullYear(this.pageDate, this.useUtc) / 10) * 10
       const decadeEnd = decadeStart + 9
       const yearSuffix = this.translation.yearSuffix
       return `${decadeStart} - ${decadeEnd}${yearSuffix}`
@@ -89,7 +93,7 @@ export default {
     },
     changeYear (incrementBy) {
       let date = this.pageDate
-      date.setYear(date.getFullYear() + incrementBy)
+      DateUtils.setFullYear(date, DateUtils.getFullYear(date, this.useUtc) + incrementBy, this.useUtc)
       this.$emit('changedDecade', date)
     },
     previousDecade () {
@@ -102,7 +106,7 @@ export default {
       if (!this.disabledDates || !this.disabledDates.to) {
         return false
       }
-      return Math.floor(this.disabledDates.to.getFullYear() / 10) * 10 >= Math.floor(this.pageDate.getFullYear() / 10) * 10
+      return Math.floor(DateUtils.getFullYear(this.disabledDates.to, this.useUtc) / 10) * 10 >= Math.floor(DateUtils.getFullYear(this.pageDate, this.useUtc) / 10) * 10
     },
     nextDecade () {
       if (this.isNextDecadeDisabled()) {
@@ -114,7 +118,7 @@ export default {
       if (!this.disabledDates || !this.disabledDates.from) {
         return false
       }
-      return Math.ceil(this.disabledDates.from.getFullYear() / 10) * 10 <= Math.ceil(this.pageDate.getFullYear() / 10) * 10
+      return Math.ceil(DateUtils.getFullYear(this.disabledDates.from, this.useUtc) / 10) * 10 <= Math.ceil(DateUtils.getFullYear(this.pageDate, this.useUtc) / 10) * 10
     },
 
     /**
@@ -123,7 +127,7 @@ export default {
      * @return {Boolean}
      */
     isSelectedYear (date) {
-      return this.selectedDate && this.selectedDate.getFullYear() === date.getFullYear()
+      return this.selectedDate && DateUtils.getFullYear(this.selectedDate, this.useUtc) === DateUtils.getFullYear(date, this.useUtc)
     },
     /**
      * Whether a year is disabled
@@ -137,12 +141,12 @@ export default {
       }
 
       if (typeof this.disabledDates.to !== 'undefined' && this.disabledDates.to) {
-        if (date.getFullYear() < this.disabledDates.to.getFullYear()) {
+        if (DateUtils.getFullYear(date, this.useUtc) < DateUtils.getFullYear(this.disabledDates.to, this.useUtc)) {
           disabledDates = true
         }
       }
       if (typeof this.disabledDates.from !== 'undefined' && this.disabledDates.from) {
-        if (date.getFullYear() > this.disabledDates.from.getFullYear()) {
+        if (DateUtils.getFullYear(date, this.useUtc) > DateUtils.getFullYear(this.disabledDates.from, this.useUtc)) {
           disabledDates = true
         }
       }

--- a/src/components/PickerYear.vue
+++ b/src/components/PickerYear.vue
@@ -21,7 +21,7 @@
   </div>
 </template>
 <script>
-import DateUtils from '../utils/DateUtils'
+import { makeDateUtils } from '../utils/DateUtils'
 export default {
   props: {
     showYearView: Boolean,
@@ -47,12 +47,12 @@ export default {
         new Date(Math.floor(d.getFullYear() / 10) * 10, d.getMonth(), d.getDate(), d.getHours(), d.getMinutes())
       for (let i = 0; i < 10; i++) {
         years.push({
-          year: DateUtils.getFullYear(dObj, this.useUtc),
+          year: this.utils.getFullYear(dObj),
           timestamp: dObj.getTime(),
           isSelected: this.isSelectedYear(dObj),
           isDisabled: this.isDisabledYear(dObj)
         })
-        DateUtils.setFullYear(dObj, DateUtils.getFullYear(dObj, this.useUtc) + 1, this.useUtc)
+        this.utils.setFullYear(dObj, this.utils.getFullYear(dObj) + 1)
       }
       return years
     },
@@ -60,7 +60,7 @@ export default {
      * @return {String}
      */
     getPageDecade () {
-      const decadeStart = Math.floor(DateUtils.getFullYear(this.pageDate, this.useUtc) / 10) * 10
+      const decadeStart = Math.floor(this.utils.getFullYear(this.pageDate) / 10) * 10
       const decadeEnd = decadeStart + 9
       const yearSuffix = this.translation.yearSuffix
       return `${decadeStart} - ${decadeEnd}${yearSuffix}`
@@ -84,6 +84,12 @@ export default {
         : this.isNextDecadeDisabled(this.pageTimestamp)
     }
   },
+  data () {
+    const constructedDateUtils = makeDateUtils(this.useUtc)
+    return {
+      utils: constructedDateUtils
+    }
+  },
   methods: {
     selectYear (year) {
       if (year.isDisabled) {
@@ -93,7 +99,7 @@ export default {
     },
     changeYear (incrementBy) {
       let date = this.pageDate
-      DateUtils.setFullYear(date, DateUtils.getFullYear(date, this.useUtc) + incrementBy, this.useUtc)
+      this.utils.setFullYear(date, this.utils.getFullYear(date) + incrementBy)
       this.$emit('changedDecade', date)
     },
     previousDecade () {
@@ -106,7 +112,7 @@ export default {
       if (!this.disabledDates || !this.disabledDates.to) {
         return false
       }
-      return Math.floor(DateUtils.getFullYear(this.disabledDates.to, this.useUtc) / 10) * 10 >= Math.floor(DateUtils.getFullYear(this.pageDate, this.useUtc) / 10) * 10
+      return Math.floor(this.utils.getFullYear(this.disabledDates.to) / 10) * 10 >= Math.floor(this.utils.getFullYear(this.pageDate) / 10) * 10
     },
     nextDecade () {
       if (this.isNextDecadeDisabled()) {
@@ -118,7 +124,7 @@ export default {
       if (!this.disabledDates || !this.disabledDates.from) {
         return false
       }
-      return Math.ceil(DateUtils.getFullYear(this.disabledDates.from, this.useUtc) / 10) * 10 <= Math.ceil(DateUtils.getFullYear(this.pageDate, this.useUtc) / 10) * 10
+      return Math.ceil(this.utils.getFullYear(this.disabledDates.from) / 10) * 10 <= Math.ceil(this.utils.getFullYear(this.pageDate) / 10) * 10
     },
 
     /**
@@ -127,7 +133,7 @@ export default {
      * @return {Boolean}
      */
     isSelectedYear (date) {
-      return this.selectedDate && DateUtils.getFullYear(this.selectedDate, this.useUtc) === DateUtils.getFullYear(date, this.useUtc)
+      return this.selectedDate && this.utils.getFullYear(this.selectedDate) === this.utils.getFullYear(date)
     },
     /**
      * Whether a year is disabled
@@ -141,12 +147,12 @@ export default {
       }
 
       if (typeof this.disabledDates.to !== 'undefined' && this.disabledDates.to) {
-        if (DateUtils.getFullYear(date, this.useUtc) < DateUtils.getFullYear(this.disabledDates.to, this.useUtc)) {
+        if (this.utils.getFullYear(date) < this.utils.getFullYear(this.disabledDates.to)) {
           disabledDates = true
         }
       }
       if (typeof this.disabledDates.from !== 'undefined' && this.disabledDates.from) {
-        if (DateUtils.getFullYear(date, this.useUtc) > DateUtils.getFullYear(this.disabledDates.from, this.useUtc)) {
+        if (this.utils.getFullYear(date) > this.utils.getFullYear(this.disabledDates.from)) {
           disabledDates = true
         }
       }

--- a/src/components/PickerYear.vue
+++ b/src/components/PickerYear.vue
@@ -42,9 +42,9 @@ export default {
       const d = this.pageDate
       let years = []
       // set up a new date object to the beginning of the current 'page'7
-      let dObj = this.useUtc ?
-        new Date(Date.UTC(Math.floor(d.getUTCFullYear() / 10) * 10, d.getUTCMonth(), d.getUTCDate())) :
-        new Date(Math.floor(d.getFullYear() / 10) * 10, d.getMonth(), d.getDate(), d.getHours(), d.getMinutes())
+      let dObj = this.useUtc
+        ? new Date(Date.UTC(Math.floor(d.getUTCFullYear() / 10) * 10, d.getUTCMonth(), d.getUTCDate()))
+        : new Date(Math.floor(d.getFullYear() / 10) * 10, d.getMonth(), d.getDate(), d.getHours(), d.getMinutes())
       for (let i = 0; i < 10; i++) {
         years.push({
           year: this.utils.getFullYear(dObj),

--- a/src/utils/DateUtils.js
+++ b/src/utils/DateUtils.js
@@ -1,86 +1,81 @@
 import en from '../locale/translations/en'
 
 const utils = {
-/**
+  /**
+   * @type {Boolean}
+   */
+  useUtc: false,
+  /**
    * Returns the full year, using UTC or not
    * @param {Date} date
-   * @param {Boolean} useUtc
    */
-  getFullYear (date, useUtc) {
-    return useUtc ? date.getUTCFullYear() : date.getFullYear()
+  getFullYear (date) {
+    return this.useUtc ? date.getUTCFullYear() : date.getFullYear()
   },
 
   /**
    * Returns the month, using UTC or not
    * @param {Date} date
-   * @param {Boolean} useUtc
    */
-  getMonth (date, useUtc) {
-    return useUtc ? date.getUTCMonth() : date.getMonth()
+  getMonth (date) {
+    return this.useUtc ? date.getUTCMonth() : date.getMonth()
   },
 
   /**
    * Returns the date, using UTC or not
    * @param {Date} date
-   * @param {Boolean} useUtc
    */
-  getDate (date, useUtc) {
-    return useUtc ? date.getUTCDate() : date.getDate()
+  getDate (date) {
+    return this.useUtc ? date.getUTCDate() : date.getDate()
   },
 
   /**
    * Returns the day, using UTC or not
    * @param {Date} date
-   * @param {Boolean} useUtc
    */
-  getDay (date, useUtc) {
-    return useUtc ? date.getUTCDay() : date.getDay()
+  getDay (date) {
+    return this.useUtc ? date.getUTCDay() : date.getDay()
   },
 
   /**
    * Returns the hours, using UTC or not
    * @param {Date} date
-   * @param {Boolean} useUtc
    */
-  getHours (date, useUtc) {
-    return useUtc ? date.getUTCHours() : date.getHours()
+  getHours (date) {
+    return this.useUtc ? date.getUTCHours() : date.getHours()
   },
 
   /**
    * Returns the minutes, using UTC or not
    * @param {Date} date
-   * @param {Boolean} useUtc
    */
-  getMinutes (date, useUtc) {
-    return useUtc ? date.getUTCMinutes() : date.getMinutes()
+  getMinutes (date) {
+    return this.useUtc ? date.getUTCMinutes() : date.getMinutes()
   },
 
   /**
    * Sets the full year, using UTC or not
    * @param {Date} date
-   * @param {Boolean} useUtc
    */
   setFullYear (date, value, useUtc) {
-    return useUtc ? date.setUTCFullYear(value) : date.setFullYear(value)
+    return this.useUtc ? date.setUTCFullYear(value) : date.setFullYear(value)
   },
 
   /**
    * Sets the month, using UTC or not
    * @param {Date} date
-   * @param {Boolean} useUtc
    */
   setMonth (date, value, useUtc) {
-    return useUtc ? date.setUTCMonth(value) : date.setMonth(value)
+    return this.useUtc ? date.setUTCMonth(value) : date.setMonth(value)
   },
 
   /**
    * Sets the date, using UTC or not
    * @param {Date} date
    * @param {Number} value
-   * @param {Boolean} useUtc
    */
   setDate (date, value, useUtc) {
-    return useUtc ? date.setUTCDate(value) : date.setDate(value)
+    return this.useUtc ? date.setUTCDate(value) : date.setDate(value)
   },
 
   /**
@@ -88,13 +83,12 @@ const utils = {
    * @see https://stackoverflow.com/a/6202196/4455925
    * @param {Date} date1
    * @param {Date} date2
-   * @param {Boolean} useUtc
    */
-  compareDates (date1, date2, useUtc) {
+  compareDates (date1, date2) {
     const d1 = new Date(date1.getTime())
     const d2 = new Date(date2.getTime())
 
-    if (useUtc) {
+    if (this.useUtc) {
       d1.setUTCHours(0, 0, 0, 0)
       d2.setUTCHours(0, 0, 0, 0)
     } else {
@@ -122,11 +116,11 @@ const utils = {
    * @param {Array}
    * @return {String}
    */
-  getDayNameAbbr (date, days, useUtc) {
+  getDayNameAbbr (date, days) {
     if (typeof date !== 'object') {
       throw TypeError('Invalid Type')
     }
-    return days[this.getDay(date, useUtc)]
+    return days[this.getDay(date)]
   },
 
   /**
@@ -135,12 +129,12 @@ const utils = {
    * @param {Array}
    * @return {String}
    */
-  getMonthName (month, months, useUtc) {
+  getMonthName (month, months) {
     if (!months) {
       throw Error('missing 2nd parameter Months array')
     }
     if (typeof month === 'object') {
-      return months[this.getMonth(month, useUtc)]
+      return months[this.getMonth(month)]
     }
     if (typeof month === 'number') {
       return months[month]
@@ -153,12 +147,12 @@ const utils = {
    * @param {Number|Date}
    * @return {String}
    */
-  getMonthNameAbbr (month, monthsAbbr, useUtc) {
+  getMonthNameAbbr (month, monthsAbbr) {
     if (!monthsAbbr) {
       throw Error('missing 2nd paramter Months array')
     }
     if (typeof month === 'object') {
-      return monthsAbbr[this.getMonth(month, useUtc)]
+      return monthsAbbr[this.getMonth(month)]
     }
     if (typeof month === 'number') {
       return monthsAbbr[month]
@@ -205,22 +199,22 @@ const utils = {
    * @param {Object}
    * @return {String}
    */
-  formatDate (date, format, translation, useUtc) {
+  formatDate (date, format, translation) {
     translation = (!translation) ? en : translation
-    let year = this.getFullYear(date, useUtc)
-    let month = this.getMonth(date, useUtc) + 1
-    let day = this.getDate(date, useUtc)
+    let year = this.getFullYear(date)
+    let month = this.getMonth(date) + 1
+    let day = this.getDate(date)
     let str = format
       .replace(/dd/, ('0' + day).slice(-2))
       .replace(/d/, day)
       .replace(/yyyy/, year)
       .replace(/yy/, String(year).slice(2))
-      .replace(/MMMM/, this.getMonthName(this.getMonth(date, useUtc), translation.months, useUtc))
-      .replace(/MMM/, this.getMonthNameAbbr(this.getMonth(date, useUtc), translation.monthsAbbr, useUtc))
+      .replace(/MMMM/, this.getMonthName(this.getMonth(date), translation.months))
+      .replace(/MMM/, this.getMonthNameAbbr(this.getMonth(date), translation.monthsAbbr))
       .replace(/MM/, ('0' + month).slice(-2))
       .replace(/M(?!a|ä|e)/, month)
-      .replace(/su/, this.getNthSuffix(this.getDate(date, useUtc)))
-      .replace(/D(?!e|é|i)/, this.getDayNameAbbr(date, translation.days, useUtc))
+      .replace(/su/, this.getNthSuffix(this.getDate(date)))
+      .replace(/D(?!e|é|i)/, this.getDayNameAbbr(date, translation.days))
     return str
   },
 
@@ -230,28 +224,20 @@ const utils = {
    * @param {Date} end
    * @return {Array}
    */
-  createDateArray (start, end, useUtc) {
+  createDateArray (start, end) {
     let dates = []
     while (start <= end) {
       dates.push(new Date(start))
-      start = this.setDate(new Date(start), this.getDate(new Date(start), useUtc) + 1, useUtc)
+      start = this.setDate(new Date(start), this.getDate(new Date(start)) + 1)
     }
     return dates
   }
 }
 
-export const makeDateUtils = useUtc => {
-  const dateUtils = {}
-
-  for (const key in utils) {
-    dateUtils[key] = (...args) => utils[key](...args, useUtc)
-  }
-  return dateUtils
-}
+export const makeDateUtils = useUtc => Object.assign(utils, {useUtc})
 
 export default {
-  ...utils,
-  makeDateUtils
+  ...utils
 }
 // eslint-disable-next-line
 ;

--- a/src/utils/DateUtils.js
+++ b/src/utils/DateUtils.js
@@ -1,8 +1,7 @@
 import en from '../locale/translations/en'
 
-export default {
-
-  /**
+const utils = {
+/**
    * Returns the full year, using UTC or not
    * @param {Date} date
    * @param {Boolean} useUtc
@@ -77,6 +76,7 @@ export default {
   /**
    * Sets the date, using UTC or not
    * @param {Date} date
+   * @param {Number} value
    * @param {Boolean} useUtc
    */
   setDate (date, value, useUtc) {
@@ -238,7 +238,20 @@ export default {
     }
     return dates
   }
+}
 
+export const makeDateUtils = useUtc => {
+  const dateUtils = {}
+
+  for (const key in utils) {
+    dateUtils[key] = (...args) => utils[key](...args, useUtc)
+  }
+  return dateUtils
+}
+
+export default {
+  ...utils,
+  makeDateUtils
 }
 // eslint-disable-next-line
 ;

--- a/src/utils/DateUtils.js
+++ b/src/utils/DateUtils.js
@@ -3,6 +3,108 @@ import en from '../locale/translations/en'
 export default {
 
   /**
+   * Returns the full year, using UTC or not
+   * @param {Date} date
+   * @param {Boolean} useUtc
+   */
+  getFullYear (date, useUtc) {
+    return useUtc ? date.getUTCFullYear() : date.getFullYear()
+  },
+
+  /**
+   * Returns the month, using UTC or not
+   * @param {Date} date
+   * @param {Boolean} useUtc
+   */
+  getMonth (date, useUtc) {
+    return useUtc ? date.getUTCMonth() : date.getMonth()
+  },
+
+  /**
+   * Returns the date, using UTC or not
+   * @param {Date} date
+   * @param {Boolean} useUtc
+   */
+  getDate (date, useUtc) {
+    return useUtc ? date.getUTCDate() : date.getDate()
+  },
+
+  /**
+   * Returns the day, using UTC or not
+   * @param {Date} date
+   * @param {Boolean} useUtc
+   */
+  getDay (date, useUtc) {
+    return useUtc ? date.getUTCDay() : date.getDay()
+  },
+
+  /**
+   * Returns the hours, using UTC or not
+   * @param {Date} date
+   * @param {Boolean} useUtc
+   */
+  getHours (date, useUtc) {
+    return useUtc ? date.getUTCHours() : date.getHours()
+  },
+
+  /**
+   * Returns the minutes, using UTC or not
+   * @param {Date} date
+   * @param {Boolean} useUtc
+   */
+  getMinutes (date, useUtc) {
+    return useUtc ? date.getUTCMinutes() : date.getMinutes()
+  },
+
+  /**
+   * Sets the full year, using UTC or not
+   * @param {Date} date
+   * @param {Boolean} useUtc
+   */
+  setFullYear (date, value, useUtc) {
+    return useUtc ? date.setUTCFullYear(value) : date.setFullYear(value)
+  },
+
+  /**
+   * Sets the month, using UTC or not
+   * @param {Date} date
+   * @param {Boolean} useUtc
+   */
+  setMonth (date, value, useUtc) {
+    return useUtc ? date.setUTCMonth(value) : date.setMonth(value)
+  },
+
+  /**
+   * Sets the date, using UTC or not
+   * @param {Date} date
+   * @param {Boolean} useUtc
+   */
+  setDate (date, value, useUtc) {
+    return useUtc ? date.setUTCDate(value) : date.setDate(value)
+  },
+
+  /**
+   * Check if date1 is equivalent to date2, without comparing the time
+   * @see https://stackoverflow.com/a/6202196/4455925
+   * @param {Date} date1
+   * @param {Date} date2
+   * @param {Boolean} useUtc
+   */
+  compareDates (date1, date2, useUtc) {
+    const d1 = new Date(date1.getTime())
+    const d2 = new Date(date2.getTime())
+
+    if (useUtc) {
+      d1.setUTCHours(0, 0, 0, 0)
+      d2.setUTCHours(0, 0, 0, 0)
+    } else {
+      d1.setHours(0, 0, 0, 0)
+      d2.setHours(0, 0, 0, 0)
+    }
+    return d1.getTime() === d2.getTime()
+  },
+
+  /**
    * Validates a date object
    * @param {Date} date - an object instantiated with the new Date constructor
    * @return {Boolean}
@@ -20,11 +122,11 @@ export default {
    * @param {Array}
    * @return {String}
    */
-  getDayNameAbbr (date, days) {
+  getDayNameAbbr (date, days, useUtc) {
     if (typeof date !== 'object') {
       throw TypeError('Invalid Type')
     }
-    return days[date.getDay()]
+    return days[this.getDay(date, useUtc)]
   },
 
   /**
@@ -33,12 +135,12 @@ export default {
    * @param {Array}
    * @return {String}
    */
-  getMonthName (month, months) {
+  getMonthName (month, months, useUtc) {
     if (!months) {
       throw Error('missing 2nd parameter Months array')
     }
     if (typeof month === 'object') {
-      return months[month.getMonth()]
+      return months[this.getMonth(month, useUtc)]
     }
     if (typeof month === 'number') {
       return months[month]
@@ -51,12 +153,12 @@ export default {
    * @param {Number|Date}
    * @return {String}
    */
-  getMonthNameAbbr (month, monthsAbbr) {
+  getMonthNameAbbr (month, monthsAbbr, useUtc) {
     if (!monthsAbbr) {
       throw Error('missing 2nd paramter Months array')
     }
     if (typeof month === 'object') {
-      return monthsAbbr[month.getMonth()]
+      return monthsAbbr[this.getMonth(month, useUtc)]
     }
     if (typeof month === 'number') {
       return monthsAbbr[month]
@@ -103,22 +205,22 @@ export default {
    * @param {Object}
    * @return {String}
    */
-  formatDate (date, format, translation) {
+  formatDate (date, format, translation, useUtc) {
     translation = (!translation) ? en : translation
-    let year = date.getFullYear()
-    let month = date.getMonth() + 1
-    let day = date.getDate()
+    let year = this.getFullYear(date, useUtc)
+    let month = this.getMonth(date, useUtc) + 1
+    let day = this.getDate(date, useUtc)
     let str = format
       .replace(/dd/, ('0' + day).slice(-2))
       .replace(/d/, day)
       .replace(/yyyy/, year)
       .replace(/yy/, String(year).slice(2))
-      .replace(/MMMM/, this.getMonthName(date.getMonth(), translation.months))
-      .replace(/MMM/, this.getMonthNameAbbr(date.getMonth(), translation.monthsAbbr))
+      .replace(/MMMM/, this.getMonthName(this.getMonth(date, useUtc), translation.months, useUtc))
+      .replace(/MMM/, this.getMonthNameAbbr(this.getMonth(date, useUtc), translation.monthsAbbr, useUtc))
       .replace(/MM/, ('0' + month).slice(-2))
       .replace(/M(?!a|ä|e)/, month)
-      .replace(/su/, this.getNthSuffix(date.getDate()))
-      .replace(/D(?!e|é|i)/, this.getDayNameAbbr(date, translation.days))
+      .replace(/su/, this.getNthSuffix(this.getDate(date, useUtc)))
+      .replace(/D(?!e|é|i)/, this.getDayNameAbbr(date, translation.days, useUtc))
     return str
   },
 
@@ -128,11 +230,11 @@ export default {
    * @param {Date} end
    * @return {Array}
    */
-  createDateArray (start, end) {
+  createDateArray (start, end, useUtc) {
     let dates = []
     while (start <= end) {
       dates.push(new Date(start))
-      start = new Date(start).setDate(new Date(start).getDate() + 1)
+      start = this.setDate(new Date(start), this.getDate(new Date(start), useUtc) + 1, useUtc)
     }
     return dates
   }

--- a/test/unit/specs/DateUtils.spec.js
+++ b/test/unit/specs/DateUtils.spec.js
@@ -116,3 +116,66 @@ describe('daysInMonth', () => {
     expect(DateUtils.daysInMonth(2017, 11)).toEqual(31) // Dec
   })
 })
+
+const getAmbiguousDate = _ => {
+  const timezoneOffset = ((new Date()).getTimezoneOffset() / 60)
+  const ambiguousHour = 25 - timezoneOffset
+  const ambiguousDate = new Date(2018, 11, 31, ambiguousHour)
+  return ambiguousDate
+}
+
+describe('UTC functions', () => {
+  it('getFullYear', () => {
+    const date = getAmbiguousDate()
+    expect(DateUtils.getFullYear(date, false)).toEqual(date.getFullYear())
+    expect(DateUtils.getFullYear(date, true)).toEqual(date.getUTCFullYear())
+  })
+
+  it('getMonth', () => {
+    const date = getAmbiguousDate()
+    expect(DateUtils.getMonth(date, false)).toEqual(date.getMonth())
+    expect(DateUtils.getMonth(date, true)).toEqual(date.getUTCMonth())
+  })
+
+  it('getDate', () => {
+    const date = getAmbiguousDate()
+    expect(DateUtils.getDate(date, false)).toEqual(date.getDate())
+    expect(DateUtils.getDate(date, true)).toEqual(date.getUTCDate())
+  })
+
+  it('getDay', () => {
+    const date = getAmbiguousDate()
+    expect(DateUtils.getDay(date, false)).toEqual(date.getDay())
+    expect(DateUtils.getDay(date, true)).toEqual(date.getUTCDay())
+  })
+
+  it('getHours', () => {
+    const date = getAmbiguousDate()
+    expect(DateUtils.getHours(date, false)).toEqual(date.getHours())
+    expect(DateUtils.getHours(date, true)).toEqual(date.getUTCHours())
+  })
+
+  it('getMinutes', () => {
+    const date = getAmbiguousDate()
+    expect(DateUtils.getMinutes(date, false)).toEqual(date.getMinutes())
+    expect(DateUtils.getMinutes(date, true)).toEqual(date.getUTCMinutes())
+  })
+
+  it('setFullYear', () => {
+    const date = getAmbiguousDate()
+    expect(DateUtils.setFullYear(date, 2018, false)).toEqual(date.setFullYear(2018))
+    expect(DateUtils.setFullYear(date, 2018, true)).toEqual(date.setUTCFullYear(2018))
+  })
+
+  it('setMonth', () => {
+    const date = getAmbiguousDate()
+    expect(DateUtils.setMonth(date, 11, false)).toEqual(date.setMonth(11))
+    expect(DateUtils.setMonth(date, 11, true)).toEqual(date.setUTCMonth(11))
+  })
+
+  it('setDate', () => {
+    const date = getAmbiguousDate()
+    expect(DateUtils.setDate(date, 31, false)).toEqual(date.setDate(31))
+    expect(DateUtils.setDate(date, 31, true)).toEqual(date.setUTCDate(31))
+  })
+})

--- a/test/unit/specs/DateUtils.spec.js
+++ b/test/unit/specs/DateUtils.spec.js
@@ -1,4 +1,4 @@
-import DateUtils from '@/utils/DateUtils'
+import DateUtils, { makeDateUtils } from '@/utils/DateUtils'
 import {en} from '@/locale'
 
 describe('DateUtils', () => {
@@ -125,57 +125,59 @@ const getAmbiguousDate = _ => {
 }
 
 describe('UTC functions', () => {
+  const utcUtils = makeDateUtils(true)
+
   it('getFullYear', () => {
     const date = getAmbiguousDate()
-    expect(DateUtils.getFullYear(date, false)).toEqual(date.getFullYear())
-    expect(DateUtils.getFullYear(date, true)).toEqual(date.getUTCFullYear())
+    expect(DateUtils.getFullYear(date)).toEqual(date.getFullYear())
+    expect(utcUtils.getFullYear(date)).toEqual(date.getUTCFullYear())
   })
 
   it('getMonth', () => {
     const date = getAmbiguousDate()
-    expect(DateUtils.getMonth(date, false)).toEqual(date.getMonth())
-    expect(DateUtils.getMonth(date, true)).toEqual(date.getUTCMonth())
+    expect(DateUtils.getMonth(date)).toEqual(date.getMonth())
+    expect(utcUtils.getMonth(date)).toEqual(date.getUTCMonth())
   })
 
   it('getDate', () => {
     const date = getAmbiguousDate()
-    expect(DateUtils.getDate(date, false)).toEqual(date.getDate())
-    expect(DateUtils.getDate(date, true)).toEqual(date.getUTCDate())
+    expect(DateUtils.getDate(date)).toEqual(date.getDate())
+    expect(utcUtils.getDate(date)).toEqual(date.getUTCDate())
   })
 
   it('getDay', () => {
     const date = getAmbiguousDate()
-    expect(DateUtils.getDay(date, false)).toEqual(date.getDay())
-    expect(DateUtils.getDay(date, true)).toEqual(date.getUTCDay())
+    expect(DateUtils.getDay(date)).toEqual(date.getDay())
+    expect(utcUtils.getDay(date)).toEqual(date.getUTCDay())
   })
 
   it('getHours', () => {
     const date = getAmbiguousDate()
-    expect(DateUtils.getHours(date, false)).toEqual(date.getHours())
-    expect(DateUtils.getHours(date, true)).toEqual(date.getUTCHours())
+    expect(DateUtils.getHours(date)).toEqual(date.getHours())
+    expect(utcUtils.getHours(date)).toEqual(date.getUTCHours())
   })
 
   it('getMinutes', () => {
     const date = getAmbiguousDate()
-    expect(DateUtils.getMinutes(date, false)).toEqual(date.getMinutes())
-    expect(DateUtils.getMinutes(date, true)).toEqual(date.getUTCMinutes())
+    expect(DateUtils.getMinutes(date)).toEqual(date.getMinutes())
+    expect(utcUtils.getMinutes(date)).toEqual(date.getUTCMinutes())
   })
 
   it('setFullYear', () => {
     const date = getAmbiguousDate()
-    expect(DateUtils.setFullYear(date, 2018, false)).toEqual(date.setFullYear(2018))
-    expect(DateUtils.setFullYear(date, 2018, true)).toEqual(date.setUTCFullYear(2018))
+    expect(DateUtils.setFullYear(date, 2018)).toEqual(date.setFullYear(2018))
+    expect(utcUtils.setFullYear(date, 2018)).toEqual(date.setUTCFullYear(2018))
   })
 
   it('setMonth', () => {
     const date = getAmbiguousDate()
-    expect(DateUtils.setMonth(date, 11, false)).toEqual(date.setMonth(11))
-    expect(DateUtils.setMonth(date, 11, true)).toEqual(date.setUTCMonth(11))
+    expect(DateUtils.setMonth(date, 11)).toEqual(date.setMonth(11))
+    expect(utcUtils.setMonth(date, 11)).toEqual(date.setUTCMonth(11))
   })
 
   it('setDate', () => {
     const date = getAmbiguousDate()
-    expect(DateUtils.setDate(date, 31, false)).toEqual(date.setDate(31))
-    expect(DateUtils.setDate(date, 31, true)).toEqual(date.setUTCDate(31))
+    expect(DateUtils.setDate(date, 31)).toEqual(date.setDate(31))
+    expect(utcUtils.setDate(date, 31)).toEqual(date.setUTCDate(31))
   })
 })

--- a/test/unit/specs/Datepicker/Datepicker.spec.js
+++ b/test/unit/specs/Datepicker/Datepicker.spec.js
@@ -1,5 +1,6 @@
 import Datepicker from '@/components/Datepicker.vue'
-import {shallow} from '@vue/test-utils'
+import DateInput from '@/components/DateInput.vue'
+import {shallow, mount} from '@vue/test-utils'
 
 describe('Datepicker unmounted', () => {
   it('has a mounted hook', () => {
@@ -203,9 +204,10 @@ describe('Datepicker.vue set by string', () => {
         value: '2016-02-20'
       }
     })
-    expect(wrapper.vm.selectedDate.getUTCFullYear()).toEqual(2016)
-    expect(wrapper.vm.selectedDate.getUTCMonth()).toEqual(1)
-    expect(wrapper.vm.selectedDate.getUTCDate()).toEqual(20)
+    const date = new Date('2016-02-20')
+    expect(wrapper.vm.selectedDate.getFullYear()).toEqual(date.getFullYear())
+    expect(wrapper.vm.selectedDate.getMonth()).toEqual(date.getMonth())
+    expect(wrapper.vm.selectedDate.getDate()).toEqual(date.getDate())
   })
 
   it('should nullify malformed value', () => {
@@ -224,12 +226,39 @@ describe('Datepicker.vue set by timestamp', () => {
     wrapper = shallow(Datepicker, {
       propsData: {
         format: 'yyyy MM dd',
-        value: 1517194697668
+        value: new Date(2018, 0, 29).getTime()
       }
     })
     expect(wrapper.vm.selectedDate.getUTCFullYear()).toEqual(2018)
     expect(wrapper.vm.selectedDate.getUTCMonth()).toEqual(0)
     expect(wrapper.vm.selectedDate.getUTCDate()).toEqual(29)
+  })
+})
+
+describe('Datepicker.vue using UTC', () => {
+  let wrapper
+  it('correctly sets the value using UTC', async () => {
+    const timezoneOffset = ((new Date()).getTimezoneOffset() / 60)
+
+    // this is ambiguous because localzone differs by one day than UTC
+    const ambiguousHour = 25 - timezoneOffset
+    const ambiguousDate = new Date(2018, 3, 15, ambiguousHour)
+    const ambiguousYear = ambiguousDate.getUTCFullYear()
+    const ambiguousMonth = (`0${ambiguousDate.getUTCMonth() + 1}`).slice(-2)
+    const ambiguousDay = (`0${ambiguousDate.getUTCDate()}`).slice(-2)
+    const UTCString = `${ambiguousYear} ${ambiguousMonth} ${ambiguousDay}`
+
+    // It's important to use the `mount` helper here
+    wrapper = mount(Datepicker, {
+      propsData: {
+        format: 'yyyy MM dd',
+        value: ambiguousDate,
+        useUtc: true // This should fail if `useUtc=false`
+      }
+    })
+    // It's important to assert the input rendered output
+    await wrapper.vm.$nextTick()
+    return expect(wrapper.find(DateInput).vm.formattedValue).toEqual(UTCString)
   })
 })
 


### PR DESCRIPTION
Hello,
I just noticed that this component always handle dates in localzone time, which is super inconvenient for absolute timestamps (UTC).

**Related issues**: #23, #200, #313, #158, #118, etc

So I added a **non-breaking change** to use **UTC** for time calculations.
This option will be available via the prop **use-utc**

Looking for your thoughts on this,
Regards