### PR TITLE
Added Slot for displaying custom html before calendar header

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,18 @@ var state = {
 </script>
 <datepicker :highlighted="state.highlighted"></datepicker>
 ```
-
+## Slots
+ 
++Sometimes you need to show custom content before the header for the calendar. 
++For such cases you can use the named slot 'beforeCalendarHeader.
++An example would be to use bootstrap's `input-group-prepend` and `input-group-append` 
++to show some custom text:
++``` html
++<datepicker :bootstrap-styling="true">
++  <div slot="beforeCalendarHeader" class="calender-header">
++    Choose a Date
++  </div>
++</datepicker>
 
 ## Translations
 

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -34,6 +34,7 @@
     <!-- Day View -->
     <template v-if="allowedToShowView('day')">
       <div :class="[calendarClass, 'vdp-datepicker__calendar']" v-show="showDayView" v-bind:style="calendarStyle">
+          <slot name="beforeCalendarHeader"></slot>
           <header>
               <span
                   @click="isRtl ? nextMonth() : previousMonth()"


### PR DESCRIPTION
In certain scenarios a custom header above the opened Calendar will be useful.

Example:

On mobile device if you want the calendar to be full viewport once opened the user will lose all context, placeholder is no longer displayed as input is focused, labels are now hidden behind full viewport. In this scenario you could use beforeCalendarHeader to display html or text or label for better UX. Also close buttons could be inserted here.