### PR TITLE
Fixed issue with vertical alignment of text in cells

### DIFF
--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -934,7 +934,7 @@ $width = 300px
         padding 0 5px
         width (100/7)%
         height 40px
-        line-height 40px
+        line-height 38px
         text-align center
         vertical-align middle
         border 1px solid transparent


### PR DESCRIPTION
I noticed that the text in the cells wasn't exactly vertically aligned. It was caused by line-height being set to 40px matching the parent container which had a border set causing the alignment to be out by 2 pixels. 