### PR TITLE
close the calendar on input blur

### DIFF
--- a/src/components/DateInput.vue
+++ b/src/components/DateInput.vue
@@ -113,15 +113,14 @@ export default {
         13  // enter
       ].includes(event.keyCode)) {
         this.input.blur()
-        this.inputBlurred()
-        this.$emit('closeCalendar')
-        return false
       }
 
-      const typedDate = Date.parse(this.input.value)
-      if (!isNaN(typedDate)) {
-        this.typedDate = this.input.value
-        this.$emit('typedDate', new Date(this.typedDate))
+      if (this.typeable) {
+        const typedDate = Date.parse(this.input.value)
+        if (!isNaN(typedDate)) {
+          this.typedDate = this.input.value
+          this.$emit('typedDate', new Date(this.typedDate))
+        }
       }
     },
     /**
@@ -129,14 +128,14 @@ export default {
      * called once the input is blurred
      */
     inputBlurred () {
-      if (!this.typedDate) {
-        return
+      if (this.typedDate && this.typeable) {
+        if (isNaN(Date.parse(this.input.value))) {
+          this.clearDate()
+        }
+        this.input.value = null
+        this.typedDate = null
       }
-      if (isNaN(Date.parse(this.input.value))) {
-        this.clearDate()
-      }
-      this.input.value = null
-      this.typedDate = null
+      this.$emit('closeCalendar')
     },
     /**
      * emit a clearDate event

--- a/src/components/DateInput.vue
+++ b/src/components/DateInput.vue
@@ -128,13 +128,16 @@ export default {
      * called once the input is blurred
      */
     inputBlurred () {
-      if (this.typedDate && this.typeable) {
-        if (isNaN(Date.parse(this.input.value))) {
-          this.clearDate()
-        }
-        this.input.value = null
-        this.typedDate = null
+      if (!this.typeable) {
+        this.$emit('closeCalendar')
+        return
       }
+
+      if (isNaN(Date.parse(this.input.value))) {
+        this.clearDate()
+      }
+      this.input.value = null
+      this.typedDate = null
       this.$emit('closeCalendar')
     },
     /**

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -284,7 +284,6 @@ export default {
       }
       this.close()
       this.showDayView = true
-      this.addOutsideClickListener()
       return true
     },
     /**
@@ -297,7 +296,6 @@ export default {
       }
       this.close()
       this.showMonthView = true
-      this.addOutsideClickListener()
       return true
     },
     /**
@@ -310,7 +308,6 @@ export default {
       }
       this.close()
       this.showYearView = true
-      this.addOutsideClickListener()
       return true
     },
     /**
@@ -410,26 +407,6 @@ export default {
      */
     setTypedDate (date) {
       this.setDate(date.getTime())
-    },
-    /**
-     * Set up an event listener for clicks outside the picker
-     */
-    addOutsideClickListener () {
-      if (!this.isInline) {
-        setTimeout(() => {
-          document.addEventListener('click', this.clickOutside, false)
-        }, 100)
-      }
-    },
-    /**
-     * Close the calendar if clicked outside the datepicker
-     * @param  {Event} event
-     */
-    clickOutside (event) {
-      if (this.$el && !this.$el.contains(event.target)) {
-        this.resetDefaultPageDate()
-        this.close(true)
-      }
     },
     /**
      * Close all calendar layers

--- a/src/components/PickerDay.vue
+++ b/src/components/PickerDay.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="[calendarClass, 'vdp-datepicker__calendar']" v-show="showDayView" :style="calendarStyle">
+  <div :class="[calendarClass, 'vdp-datepicker__calendar']" v-show="showDayView" :style="calendarStyle" @mousedown.prevent>
     <header>
       <span
         @click="isRtl ? nextMonth() : previousMonth()"

--- a/src/components/PickerMonth.vue
+++ b/src/components/PickerMonth.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="[calendarClass, 'vdp-datepicker__calendar']" v-show="showMonthView" :style="calendarStyle">
+  <div :class="[calendarClass, 'vdp-datepicker__calendar']" v-show="showMonthView" :style="calendarStyle" @mousedown.prevent>
     <header>
       <span
         @click="previousYear"

--- a/src/components/PickerYear.vue
+++ b/src/components/PickerYear.vue
@@ -1,5 +1,5 @@
 <template>
-  <div :class="[calendarClass, 'vdp-datepicker__calendar']" v-show="showYearView" :style="calendarStyle">
+  <div :class="[calendarClass, 'vdp-datepicker__calendar']" v-show="showYearView" :style="calendarStyle" @mousedown.prevent>
     <header>
       <span @click="previousDecade" class="prev"
         :class="{ 'disabled' : isPreviousDecadeDisabled(pageTimestamp) }">&lt;</span>

--- a/test/unit/specs/DateInput/DateInput.spec.js
+++ b/test/unit/specs/DateInput/DateInput.spec.js
@@ -75,4 +75,9 @@ describe('DateInput', () => {
     })
     expect(wrapper.find('input').element.value).toEqual('!')
   })
+
+  it('triggers closeCalendar on blur', () => {
+    wrapper.find('input').trigger('blur')
+    expect(wrapper.emitted('closeCalendar')).toBeTruthy()
+  })
 })

--- a/test/unit/specs/DateInput/typedDates.spec.js
+++ b/test/unit/specs/DateInput/typedDates.spec.js
@@ -32,6 +32,7 @@ describe('DateInput', () => {
   it('emits the date when typed', () => {
     const input = wrapper.find('input')
     wrapper.vm.input.value = '2018-04-24'
+    input.trigger('keypress')
     input.trigger('keyup')
     expect(wrapper.emitted().typedDate).toBeDefined()
     expect(wrapper.emitted().typedDate[0][0]).toBeInstanceOf(Date)
@@ -39,12 +40,9 @@ describe('DateInput', () => {
 
   it('emits closeCalendar when return is pressed', () => {
     const input = wrapper.find('input')
+    const blurSpy = jest.spyOn(input.element, 'blur')
     input.trigger('keyup', {keyCode: 13})
-    expect(wrapper.emitted().closeCalendar).toBeDefined()
-  })
-
-  it('returns when blurred if date has not been typed', () => {
-    expect(wrapper.vm.inputBlurred()).toBeFalsy()
+    expect(blurSpy).toBeCalled()
   })
 
   it('clears a typed date if it does not parse', () => {

--- a/test/unit/specs/DateInput/typedDates.spec.js
+++ b/test/unit/specs/DateInput/typedDates.spec.js
@@ -15,6 +15,13 @@ describe('DateInput', () => {
     })
   })
 
+  it('allows typing', () => {
+    wrapper.setProps({typeable: true})
+    expect(wrapper.vm.allowTyping()).toEqual(true)
+    wrapper.setProps({typeable: false})
+    expect(wrapper.vm.allowTyping({preventDefault: () => {}})).toEqual(false)
+  })
+
   it('does not format the date when typed', () => {
     const dateString = '2018-04-24'
     wrapper.vm.input.value = dateString

--- a/test/unit/specs/DateInput/typedDates.spec.js
+++ b/test/unit/specs/DateInput/typedDates.spec.js
@@ -32,7 +32,6 @@ describe('DateInput', () => {
   it('emits the date when typed', () => {
     const input = wrapper.find('input')
     wrapper.vm.input.value = '2018-04-24'
-    input.trigger('keypress')
     input.trigger('keyup')
     expect(wrapper.emitted().typedDate).toBeDefined()
     expect(wrapper.emitted().typedDate[0][0]).toBeInstanceOf(Date)

--- a/test/unit/specs/Datepicker/Datepicker.spec.js
+++ b/test/unit/specs/Datepicker/Datepicker.spec.js
@@ -43,7 +43,7 @@ describe('Datepicker mounted', () => {
     wrapper.vm.setValue()
     expect(wrapper.vm.selectedDate).toEqual(null)
     const pageDate = new Date(wrapper.vm.pageDate)
-    expect(pageDate.getYear()).toEqual(now.getYear())
+    expect(pageDate.getFullYear()).toEqual(now.getFullYear())
     expect(pageDate.getMonth()).toEqual(now.getMonth())
     expect(pageDate.getDate()).toEqual(1)
   })
@@ -98,15 +98,6 @@ describe('Datepicker mounted', () => {
     expect(wrapper.vm.isOpen).toEqual(false)
   })
 
-  it('should close the picker when clicked outside', () => {
-    jest.useFakeTimers()
-    wrapper.vm.showCalendar()
-    jest.runAllTimers()
-    expect(wrapper.vm.isOpen).toEqual(true)
-    document.body.click()
-    expect(wrapper.vm.isOpen).toEqual(false)
-  })
-
   it('can select a day', () => {
     const date = new Date(2016, 9, 1)
     wrapper.vm.selectDate({timestamp: date.getTime()})
@@ -139,10 +130,23 @@ describe('Datepicker mounted', () => {
     expect(wrapper.vm.pageDate.getFullYear()).toEqual(today.getFullYear())
     expect(wrapper.vm.pageDate.getMonth()).toEqual(today.getMonth())
     expect(wrapper.vm.pageDate.getDate()).toEqual(1)
-    wrapper.vm.setPageDate(new Date(2020, 3, 20))
     wrapper.vm.resetDefaultPageDate()
     expect(wrapper.vm.pageDate.getFullYear()).toEqual(today.getFullYear())
     expect(wrapper.vm.pageDate.getMonth()).toEqual(today.getMonth())
+    expect(wrapper.vm.pageDate.getDate()).toEqual(1)
+  })
+
+  it('does not set the default page date if a date is selected', () => {
+    const wrapper = shallow(Datepicker)
+    const today = new Date()
+    const pastDate = new Date(2018, 3, 20)
+    expect(wrapper.vm.pageDate.getFullYear()).toEqual(today.getFullYear())
+    expect(wrapper.vm.pageDate.getMonth()).toEqual(today.getMonth())
+    expect(wrapper.vm.pageDate.getDate()).toEqual(1)
+    wrapper.vm.setDate(pastDate.getTime())
+    wrapper.vm.resetDefaultPageDate()
+    expect(wrapper.vm.pageDate.getFullYear()).toEqual(pastDate.getFullYear())
+    expect(wrapper.vm.pageDate.getMonth()).toEqual(pastDate.getMonth())
     expect(wrapper.vm.pageDate.getDate()).toEqual(1)
   })
 
@@ -199,9 +203,9 @@ describe('Datepicker.vue set by string', () => {
         value: '2016-02-20'
       }
     })
-    expect(wrapper.vm.selectedDate.getFullYear()).toEqual(2016)
-    expect(wrapper.vm.selectedDate.getMonth()).toEqual(1)
-    expect(wrapper.vm.selectedDate.getDate()).toEqual(20)
+    expect(wrapper.vm.selectedDate.getUTCFullYear()).toEqual(2016)
+    expect(wrapper.vm.selectedDate.getUTCMonth()).toEqual(1)
+    expect(wrapper.vm.selectedDate.getUTCDate()).toEqual(20)
   })
 
   it('should nullify malformed value', () => {
@@ -223,9 +227,9 @@ describe('Datepicker.vue set by timestamp', () => {
         value: 1517194697668
       }
     })
-    expect(wrapper.vm.selectedDate.getFullYear()).toEqual(2018)
-    expect(wrapper.vm.selectedDate.getMonth()).toEqual(0)
-    expect(wrapper.vm.selectedDate.getDate()).toEqual(29)
+    expect(wrapper.vm.selectedDate.getUTCFullYear()).toEqual(2018)
+    expect(wrapper.vm.selectedDate.getUTCMonth()).toEqual(0)
+    expect(wrapper.vm.selectedDate.getUTCDate()).toEqual(29)
   })
 })
 


### PR DESCRIPTION
Change the calendar close implementation.
Remove document click handler (which may fail if click propagation is stopped by another handler).
Use input blur event instead.
Use @mousedown.prevent on calendar containers to prevent change in focus from the input to the calendar.

Closes #484