### PR TITLE
README - fix typo in Disabled Dates script

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ var state = {
   }
 }
 </script>
-<datepicker :disabledDates="state.disabledDates"></datepicker>
+<datepicker :disabled="state.disabledDates"></datepicker>
 ```
 
 ## Highlighted Dates


### PR DESCRIPTION
I was stuck for quite some time after using `:disabledDates` instead of `:disabled` as shown in the README. This fix update the readme accordingly