### PR TITLE
Day cell override

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Inline always open version
 | id                            | String          |             | Input id                                 |
 | format                        | String\|Function| dd MMM yyyy | Date formatting string or function       |
 | full-month-name               | Boolean         | false       | To show the full month name              |
-| language                      | String          | en          | Translation for days and months          |
+| language                      | Object          | en          | Translation for days and months          |
 | disabled-dates                | Object          |             | See below for configuration              |
 | placeholder                   | String          |             | Input placeholder text                   |
 | inline                        | Boolean         |             | To show the datepicker always open       |
@@ -218,7 +218,7 @@ var state = {
   }
 }
 </script>
-<datepicker :disabled="state.disabledDates"></datepicker>
+<datepicker :disabledDates="state.disabledDates"></datepicker>
 ```
 
 ## Highlighted Dates

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -44,6 +44,7 @@
       :pageTimestamp="pageTimestamp"
       :isRtl="isRtl"
       :mondayFirst="mondayFirst"
+      :dayCellContent="dayCellContent"
       @changedMonth="setPageDate"
       @selectDate="selectDate"
       @showMonthCalendar="showMonthCalendar"
@@ -120,6 +121,7 @@ export default {
         return val === null || val instanceof Date || typeof val === 'string' || typeof val === 'number'
       }
     },
+    dayCellContent: Function,
     fullMonthName: Boolean,
     disabledDates: Object,
     highlighted: Object,

--- a/src/components/PickerDay.vue
+++ b/src/components/PickerDay.vue
@@ -21,7 +21,8 @@
           v-for="day in days"
           :key="day.timestamp"
           :class="dayClasses(day)"
-          @click="selectDate(day)">{{ day.date }}</span>
+          v-html="dayCellContent(day)"
+          @click="selectDate(day)"></span>
     </div>
   </div>
 </template>
@@ -35,6 +36,12 @@ export default {
     pageTimestamp: Number,
     fullMonthName: Boolean,
     allowedToShowView: Function,
+    dayCellContent: {
+        type: Function,
+        default: (day) => {
+          return day.date;
+        },
+    },
     disabledDates: Object,
     highlighted: Object,
     calendarClass: [String, Object, Array],


### PR DESCRIPTION
This patch allows for taking control over the exact content of a day cell. Like this, additional information can be rendered into the day cell (daily price information in my case).
This patch contains no BC breaks.