### PR TITLE
Introduce override hook for day cell content (no BC breaks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Inline always open version
 | calendar-button               | Boolean         | false       | Show an icon that that can be clicked    |
 | calendar-button-icon          | String          |             | Use icon for button (ex: fa fa-calendar) |
 | calendar-button-icon-content  | String          |             | Use for material-icons (ex: event)       |
-| dayCellContent                | Function        | day.date    | Use to render custom content in day cell |
+| day-cell-content              | Function        |             | Use to render custom content in day cell |
 | bootstrap-styling             | Boolean         | false       | Output bootstrap styling classes         |
 | initial-view                  | String          | minimumView | If set, open on that view                |
 | disabled                      | Boolean         | false       | If true, disable Datepicker on screen    |

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Inline always open version
 | calendar-button               | Boolean         | false       | Show an icon that that can be clicked    |
 | calendar-button-icon          | String          |             | Use icon for button (ex: fa fa-calendar) |
 | calendar-button-icon-content  | String          |             | Use for material-icons (ex: event)       |
+| dayCellContent                | Function        | day.date    | Use to render custom content in day cell |
 | bootstrap-styling             | Boolean         | false       | Output bootstrap styling classes         |
 | initial-view                  | String          | minimumView | If set, open on that view                |
 | disabled                      | Boolean         | false       | If true, disable Datepicker on screen    |

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -44,6 +44,7 @@
       :pageTimestamp="pageTimestamp"
       :isRtl="isRtl"
       :mondayFirst="mondayFirst"
+      :dayCellContent="dayCellContent"
       @changedMonth="setPageDate"
       @selectDate="selectDate"
       @showMonthCalendar="showMonthCalendar"
@@ -120,6 +121,7 @@ export default {
         return val === null || val instanceof Date || typeof val === 'string' || typeof val === 'number'
       }
     },
+    dayCellContent: Function,
     fullMonthName: Boolean,
     disabledDates: Object,
     highlighted: Object,

--- a/src/components/PickerDay.vue
+++ b/src/components/PickerDay.vue
@@ -21,7 +21,8 @@
           v-for="day in days"
           :key="day.timestamp"
           :class="dayClasses(day)"
-          @click="selectDate(day)">{{ day.date }}</span>
+          v-html="dayCellContent(day)"
+          @click="selectDate(day)"></span>
     </div>
   </div>
 </template>
@@ -35,6 +36,12 @@ export default {
     pageTimestamp: Number,
     fullMonthName: Boolean,
     allowedToShowView: Function,
+    dayCellContent: {
+        type: Function,
+        default: (day) => {
+          return day.date;
+        },
+    },
     disabledDates: Object,
     highlighted: Object,
     calendarClass: [String, Object, Array],

--- a/src/components/PickerDay.vue
+++ b/src/components/PickerDay.vue
@@ -38,9 +38,7 @@ export default {
     allowedToShowView: Function,
     dayCellContent: {
         type: Function,
-        default: (day) => {
-          return day.date;
-        },
+        default: day => day.date,
     },
     disabledDates: Object,
     highlighted: Object,


### PR DESCRIPTION
This patch allows for taking control over the exact content of a day cell. Like this, additional information can be rendered into the day cell (daily price information in my case).
This patch contains no BC breaks.