### PR TITLE
dont propagate clicks

### DIFF
--- a/src/components/PickerDay.vue
+++ b/src/components/PickerDay.vue
@@ -3,12 +3,12 @@
     <slot name="beforeCalendarHeader"></slot>
     <header>
       <span
-        @click="isRtl ? nextMonth() : previousMonth()"
+        @click.stop.prevent="isRtl ? nextMonth() : previousMonth()"
         class="prev"
         :class="{ 'disabled' : isRtl ? isNextMonthDisabled(pageTimestamp) : isPreviousMonthDisabled(pageTimestamp) }">&lt;</span>
-      <span class="day__month_btn" @click="showMonthCalendar" :class="allowedToShowView('month') ? 'up' : ''">{{ isYmd ? currYearName : currMonthName }} {{ isYmd ? currMonthName : currYearName }}</span>
+      <span class="day__month_btn" @click.stop.prevent="showMonthCalendar" :class="allowedToShowView('month') ? 'up' : ''">{{ isYmd ? currYearName : currMonthName }} {{ isYmd ? currMonthName : currYearName }}</span>
       <span
-        @click="isRtl ? previousMonth() : nextMonth()"
+        @click.stop.prevent="isRtl ? previousMonth() : nextMonth()"
         class="next"
         :class="{ 'disabled' : isRtl ? isPreviousMonthDisabled(pageTimestamp) : isNextMonthDisabled(pageTimestamp) }">&gt;</span>
     </header>

--- a/src/components/PickerMonth.vue
+++ b/src/components/PickerMonth.vue
@@ -3,12 +3,12 @@
     <slot name="beforeCalendarHeader"></slot>
     <header>
       <span
-        @click="previousYear"
+        @click.stop.prevent="previousYear"
         class="prev"
         :class="{ 'disabled' : isPreviousYearDisabled(pageTimestamp) }">&lt;</span>
-      <span class="month__year_btn" @click="showYearCalendar" :class="allowedToShowView('year') ? 'up' : ''">{{ pageYearName }}</span>
+      <span class="month__year_btn" @click.stop.prevent="showYearCalendar" :class="allowedToShowView('year') ? 'up' : ''">{{ pageYearName }}</span>
       <span
-        @click="nextYear"
+        @click.stop.prevent="nextYear"
         class="next"
         :class="{ 'disabled' : isNextYearDisabled(pageTimestamp) }">&gt;</span>
     </header>
@@ -16,7 +16,7 @@
       v-for="month in months"
       :key="month.timestamp"
       :class="{'selected': month.isSelected, 'disabled': month.isDisabled}"
-      @click.stop="selectMonth(month)">{{ month.month }}</span>
+      @click.stop.prevent="selectMonth(month)">{{ month.month }}</span>
   </div>
 </template>
 <script>

--- a/src/components/PickerYear.vue
+++ b/src/components/PickerYear.vue
@@ -2,10 +2,10 @@
   <div :class="[calendarClass, 'vdp-datepicker__calendar']" v-show="showYearView" :style="calendarStyle" @mousedown.prevent>
     <slot name="beforeCalendarHeader"></slot>
     <header>
-      <span @click="previousDecade" class="prev"
+      <span @click.stop.prevent="previousDecade" class="prev"
         :class="{ 'disabled' : isPreviousDecadeDisabled(pageTimestamp) }">&lt;</span>
       <span>{{ getPageDecade }}</span>
-      <span @click="nextDecade" class="next"
+      <span @click.stop.prevent="nextDecade" class="next"
         :class="{ 'disabled' : isNextDecadeDisabled(pageTimestamp) }">&gt;</span>
     </header>
     <span
@@ -13,7 +13,7 @@
       v-for="year in years"
       :key="year.timestamp"
       :class="{ 'selected': year.isSelected, 'disabled': year.isDisabled }"
-      @click.stop="selectYear(year)">{{ year.year }}</span>
+      @click.stop.prevent="selectYear(year)">{{ year.year }}</span>
   </div>
 </template>
 <script>


### PR DESCRIPTION
Click the nav buttons on various pickers would close the picker. This adds `preventDefault` and `stopPropagation` to those buttons.