### PR TITLE
Emit month change event also if change came through PickerDay

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Inline always open version
 | calendar-button               | Boolean         | false       | Show an icon that that can be clicked    |
 | calendar-button-icon          | String          |             | Use icon for button (ex: fa fa-calendar) |
 | calendar-button-icon-content  | String          |             | Use for material-icons (ex: event)       |
+| dayCellContent                | Function        | day.date    | Use to render custom content in day cell |
 | bootstrap-styling             | Boolean         | false       | Output bootstrap styling classes         |
 | initial-view                  | String          | minimumView | If set, open on that view                |
 | disabled                      | Boolean         | false       | If true, disable Datepicker on screen    |

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -48,7 +48,7 @@
       :mondayFirst="mondayFirst"
       :dayCellContent="dayCellContent"
       :use-utc="useUtc"
-      @changedMonth="setPageDate"
+      @changedMonth="handleChangedMonthFromDayPicker"
       @selectDate="selectDate"
       @showMonthCalendar="showMonthCalendar"
       @selectedDisabled="selectDisabledDate">
@@ -421,7 +421,13 @@ export default {
         }
       }
       this.pageTimestamp = this.utils.setDate(new Date(date), 1)
-      this.$emit('changedMonth', date)
+    },
+    /**
+     * Handles a month change from the day picker
+     */
+    handleChangedMonthFromDayPicker (date) {
+        this.setPageDate(date)
+        this.$emit('changedMonth', date)
     },
     /**
      * Set the date from a typedDate event

--- a/test/unit/specs/Datepicker/Datepicker.spec.js
+++ b/test/unit/specs/Datepicker/Datepicker.spec.js
@@ -200,6 +200,12 @@ describe('Datepicker mounted', () => {
     await wrapper.vm.$nextTick()
     expect(spy).toBeCalled()
   })
+
+  it('should emit changedMonth on a month change received from PickerDay', () => {
+    const date = new Date(2016, 9, 1)
+    wrapper.vm.handleChangedMonthFromDayPicker({timestamp: date.getTime()})
+    expect(wrapper.emitted().changedMonth).toBeTruthy()
+  })
 })
 
 describe('Datepicker.vue set by string', () => {


### PR DESCRIPTION
So far, the 'changedMonth' event only gets emitted, if the change originally came from PickerMonth. If the month was changed through PickerDay (with the arrows), there was no way of knowing that outside of the Datepicker component so far.