### PR TITLE
fix: #522 - closed event not firing when clicking outside calendar

### DIFF
--- a/src/components/DateInput.vue
+++ b/src/components/DateInput.vue
@@ -141,7 +141,7 @@ export default {
         this.typedDate = null
       }
 
-      this.$emit('closeCalendar')
+      this.$emit('closeCalendar', true)
     },
     /**
      * emit a clearDate event


### PR DESCRIPTION
Added the closed event when clicking outside calendar without selecting a value.