### PR TITLE
Fix Date.parse format

### DIFF
--- a/src/components/DateInput.vue
+++ b/src/components/DateInput.vue
@@ -57,6 +57,7 @@ export default {
     disabled: Boolean,
     required: Boolean,
     typeable: Boolean,
+    formatTypedDate: Function,
     bootstrapStyling: Boolean
   },
   data () {
@@ -123,10 +124,10 @@ export default {
       }
 
       if (this.typeable) {
-        const typedDate = Date.parse(this.input.value)
-        if (!isNaN(typedDate)) {
+        const parsedDate = Date.parse(this.getTypedDate(this.input.value))
+        if (!isNaN(parsedDate)) {
           this.typedDate = this.input.value
-          this.$emit('typedDate', new Date(this.typedDate))
+          this.$emit('typedDate', new Date(parsedDate))
         }
       }
     },
@@ -135,7 +136,7 @@ export default {
      * called once the input is blurred
      */
     inputBlurred () {
-      if (this.typeable && isNaN(Date.parse(this.input.value))) {
+      if (this.typeable && isNaN(Date.parse(this.getTypedDate(this.input.value)))) {
         this.clearDate()
         this.input.value = null
         this.typedDate = null
@@ -148,6 +149,15 @@ export default {
      */
     clearDate () {
       this.$emit('clearDate')
+    },
+    /**
+     * format Date with regular or custom function
+     */
+    getTypedDate (input) {
+      let date = typeof this.formatTypedDate === 'function'
+        ? this.formatTypedDate(input)
+        : input
+      return date
     }
   },
   mounted () {

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -13,6 +13,7 @@
       :placeholder="placeholder"
       :inputClass="inputClass"
       :typeable="typeable"
+      :format-typed-date="formatTypedDate"
       :clearButton="clearButton"
       :clearButtonIcon="clearButtonIcon"
       :calendarButton="calendarButton"
@@ -144,6 +145,7 @@ export default {
     disabled: Boolean,
     required: Boolean,
     typeable: Boolean,
+    formatTypedDate: Function,
     minimumView: {
       type: String,
       default: 'day'

--- a/test/unit/specs/DateInput/typedDates.spec.js
+++ b/test/unit/specs/DateInput/typedDates.spec.js
@@ -44,6 +44,24 @@ describe('DateInput', () => {
     expect(wrapper.emitted().typedDate[0][0]).toBeInstanceOf(Date)
   })
 
+  it('allows custom date format', () => {
+    const dateString = '24/06/2018'
+    wrapper.setProps({
+      selectedDate: new Date(dateString),
+      typeable: true,
+      formatTypedDate: function (dateString) {
+        let result = dateString.split('/')
+        return result[2] + '-' + result[1] + '-' + result[0] + 'T00:00:00-03:00'
+      }
+    })
+    const input = wrapper.find('input')
+    wrapper.vm.input.value = dateString
+    expect(wrapper.vm.input.value).toEqual(dateString)
+    input.trigger('keyup')
+    expect(wrapper.emitted().typedDate[0][0].toISOString()).toEqual('2018-06-24T03:00:00.000Z')
+    expect(wrapper.vm.formattedValue).toEqual(dateString)
+  })
+
   it('emits closeCalendar when return is pressed', () => {
     const input = wrapper.find('input')
     const blurSpy = jest.spyOn(input.element, 'blur')


### PR DESCRIPTION
A solution to the Date.parse problem. (Issue #486)

Because `Date.parse` only accepts specific formats, the solution was to format the date before the parser.

For this we have added a new prop `formatTypedDate`, which receives a function that must format the date into a format known by `Date.parse`.

To not have problems with time, I transform the date in ISO format
`YYYY-MM-DDTHH: mm: ss.sssZ`, so you can also use the local time zone.

**Example:**
 
Check-in date `15/06/2018` (dd/mm/yyyy) with local time zone GMT -3: 00 (Brazil):

```
formatTypedDate (date) {
    let result = date.split("/");
    return result [2] + '-' + result [1] + '-' + result [0] + 'T00:00:00-03:00';
}
```

which returns me `2018-06-15T00:00:00-03:00`.