### PR TITLE
Fix regression: selectedDisabled correctly emits the object again

### DIFF
--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -51,7 +51,7 @@
       @changedMonth="setPageDate"
       @selectDate="selectDate"
       @showMonthCalendar="showMonthCalendar"
-      @selectedDisabled="$emit('selectedDisabled')">
+      @selectedDisabled="selectDisabledDate">
       <slot name="beforeCalendarHeader" slot="beforeCalendarHeader"></slot>
     </picker-day>
 
@@ -359,6 +359,12 @@ export default {
         this.close(true)
       }
       this.resetTypedDate = new Date()
+    },
+    /**
+     * @param {Object} date
+     */
+    selectDisabledDate (date) {
+      this.$emit('selectedDisabled', date)
     },
     /**
      * @param {Object} month

--- a/test/unit/specs/Datepicker/Datepicker.spec.js
+++ b/test/unit/specs/Datepicker/Datepicker.spec.js
@@ -99,12 +99,19 @@ describe('Datepicker mounted', () => {
     expect(wrapper.vm.isOpen).toEqual(false)
   })
 
+  it('should emit selectedDisabled on a disabled timestamp', () => {
+    const date = new Date(2016, 9, 1)
+    wrapper.vm.selectDisabledDate({timestamp: date.getTime()})
+    expect(wrapper.emitted().selectedDisabled).toBeTruthy()
+  })
+
   it('can select a day', () => {
     const date = new Date(2016, 9, 1)
     wrapper.vm.selectDate({timestamp: date.getTime()})
     expect(wrapper.vm.pageTimestamp).toEqual(date.getTime())
     expect(wrapper.vm.selectedDate.getMonth()).toEqual(9)
     expect(wrapper.vm.showDayView).toEqual(false)
+    expect(wrapper.emitted().selected).toBeTruthy()
   })
 
   it('can select a month', () => {

--- a/test/unit/specs/PickerDay/disabledDates.spec.js
+++ b/test/unit/specs/PickerDay/disabledDates.spec.js
@@ -106,4 +106,9 @@ describe('PickerDay: disabled', () => {
     expect(wrapper.vm.isDisabledDate(new Date(2016, 10, 24))).toEqual(true)
     expect(wrapper.vm.isDisabledDate(new Date(2016, 9, 11))).toEqual(false)
   })
+
+  it('should emit a selectedDisabled event for a disabled date', () => {
+    expect(wrapper.vm.selectDate({isDisabled: true})).toEqual(false)
+    expect(wrapper.emitted().selectedDisabled).toBeTruthy()
+  })
 })


### PR DESCRIPTION
Fixes #306 which was broken due to format changes (undefined instead of object passed along)