### PR TITLE
Fix bugs related to the presence of time in date objects

### DIFF
--- a/src/components/DateInput.vue
+++ b/src/components/DateInput.vue
@@ -45,7 +45,11 @@ export default {
     id: String,
     name: String,
     refName: String,
-    openDate: Date,
+    openDate: {
+      validator: (val) => {
+        return val === null || val instanceof Date || typeof val === 'string' || typeof val === 'number'
+      }
+    },
     placeholder: String,
     inputClass: [String, Object, Array],
     clearButton: Boolean,

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -162,6 +162,7 @@ export default {
   data () {
     const startDate = this.openDate ? new Date(this.openDate) : new Date()
     const constructedDateUtils = makeDateUtils(this.useUtc)
+    constructedDateUtils.resetDateTime(startDate)
     const pageTimestamp = constructedDateUtils.setDate(startDate, 1)
     return {
       /*
@@ -186,7 +187,7 @@ export default {
        * Positioning
        */
       calendarHeight: 0,
-      resetTypedDate: new Date(),
+      resetTypedDate: constructedDateUtils.getNewDateObject(),
       utils: constructedDateUtils
     }
   },
@@ -358,7 +359,7 @@ export default {
       if (!this.isInline) {
         this.close(true)
       }
-      this.resetTypedDate = new Date()
+      this.resetTypedDate = this.utils.getNewDateObject()
     },
     /**
      * @param {Object} date
@@ -419,6 +420,7 @@ export default {
         } else {
           date = new Date()
         }
+        this.utils.resetDateTime(date)
       }
       this.pageTimestamp = this.utils.setDate(new Date(date), 1)
     },

--- a/src/components/PickerDay.vue
+++ b/src/components/PickerDay.vue
@@ -103,7 +103,7 @@ export default {
           isHighlighted: this.isHighlightedDate(dObj),
           isHighlightStart: this.isHighlightStart(dObj),
           isHighlightEnd: this.isHighlightEnd(dObj),
-          isToday: this.utils.compareDates(dObj, new Date()),
+          isToday: this.utils.compareDates(dObj, this.utils.getNewDateObject()),
           isWeekend: this.utils.getDay(dObj) === 0 || this.utils.getDay(dObj) === 6,
           isSaturday: this.utils.getDay(dObj) === 6,
           isSunday: this.utils.getDay(dObj) === 0

--- a/src/utils/DateUtils.js
+++ b/src/utils/DateUtils.js
@@ -88,13 +88,9 @@ const utils = {
     const d1 = new Date(date1.getTime())
     const d2 = new Date(date2.getTime())
 
-    if (this.useUtc) {
-      d1.setUTCHours(0, 0, 0, 0)
-      d2.setUTCHours(0, 0, 0, 0)
-    } else {
-      d1.setHours(0, 0, 0, 0)
-      d2.setHours(0, 0, 0, 0)
-    }
+    this.resetDateTime(d1)
+    this.resetDateTime(d2)
+
     return d1.getTime() === d2.getTime()
   },
 
@@ -231,6 +227,30 @@ const utils = {
       start = this.setDate(new Date(start), this.getDate(new Date(start)) + 1)
     }
     return dates
+  },
+
+  /**
+   * Remove hours/minutes/seconds/milliseconds from a date object
+   * @param {Date} date
+   * @return {Date}
+   */
+  resetDateTime (date) {
+    if (this.useUtc) {
+      date.setUTCHours(0, 0, 0, 0)
+    } else {
+      date.setHours(0, 0, 0, 0)
+    }
+    return date
+  },
+
+  /**
+   * Return a new date object with hours/minutes/seconds/milliseconds removed
+   * @return {Date}
+   */
+  getNewDateObject () {
+    var d = new Date()
+    this.resetDateTime(d)
+    return d
   }
 }
 


### PR DESCRIPTION
I faced a bug that made me pull my hairs off for hours, but I've finally found the problem ! :fist_raised: 

**Here is a summary of my bug :** 
In my project I have two different datepickers, I pass them the exact same value for `disabled-dates` but for some reasons, one of them was displaying my available dates correctly while the other was showing every dates as disabled... arg ! Turns out the only difference between those two was that the first one had an initial date selected, while the other had none. So I dug from there...

**Explanation :**
And discovered that if no initial value is defined, a new date object would be created (`new Date()`) which would incorporate current time. Things works anyway, until it reaches that point : https://github.com/wmcmurray/vuejs-datepicker/blob/30d81e56a7f7f4cd05388266d48eaaa76d76bc4a/src/components/PickerDay.vue#L263 

in my case it was checking (for exemple) if `Jan 06 2019 19:00:00   >   Jan 06 2019 00:00:00` and was returning true because yes, its 19 hours bigger, so Jan 06 was shown as disabled even if it shouldn't.

**Solution :**
So I searched for every places where a new date object is created without params or with a user specified value (ex: `openDate` prop), and made sure the time is set to 0 on those.


_**BONUS POINTS :** also found that the `openDate` prop validation in `DateInput.vue` was not the same as in `Datepicker.vue` (which where causing a vuejs error in console when we pass a string value)._

Hope my explanations are clear enough ! :slightly_smiling_face: 