### PR TITLE
Add readonly attribute to DateInput when it isn't typeable

### DIFF
--- a/src/components/DateInput.vue
+++ b/src/components/DateInput.vue
@@ -125,7 +125,7 @@ export default {
       // close calendar if escape or enter are pressed
       if ([
         27, // escape
-        13  // enter
+        13 // enter
       ].includes(event.keyCode)) {
         this.input.blur()
       }

--- a/src/components/DateInput.vue
+++ b/src/components/DateInput.vue
@@ -22,7 +22,7 @@
       :clear-button="clearButton"
       :disabled="disabled"
       :required="required"
-      :readonly="readonly"
+      :readonly="!typeable"
       @click="showCalendar"
       @keydown="allowTyping"
       @keyup="parseTypedDate"
@@ -61,7 +61,6 @@ export default {
     calendarButtonIconContent: String,
     disabled: Boolean,
     required: Boolean,
-    readonly: Boolean,
     typeable: Boolean,
     bootstrapStyling: Boolean,
     useUtc: Boolean

--- a/src/components/DateInput.vue
+++ b/src/components/DateInput.vue
@@ -22,6 +22,7 @@
       :clear-button="clearButton"
       :disabled="disabled"
       :required="required"
+      :readonly="readonly"
       @click="showCalendar"
       @keydown="allowTyping"
       @keyup="parseTypedDate"
@@ -60,6 +61,7 @@ export default {
     calendarButtonIconContent: String,
     disabled: Boolean,
     required: Boolean,
+    readonly: Boolean,
     typeable: Boolean,
     bootstrapStyling: Boolean,
     useUtc: Boolean

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -20,6 +20,7 @@
       :calendarButtonIconContent="calendarButtonIconContent"
       :disabled="disabled"
       :required="required"
+      :readonly="readonly"
       :bootstrapStyling="bootstrapStyling"
       :use-utc="useUtc"
       @showCalendar="showCalendar"
@@ -148,6 +149,7 @@ export default {
     initialView: String,
     disabled: Boolean,
     required: Boolean,
+    readonly: Boolean,
     typeable: Boolean,
     useUtc: Boolean,
     minimumView: {

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -20,7 +20,6 @@
       :calendarButtonIconContent="calendarButtonIconContent"
       :disabled="disabled"
       :required="required"
-      :readonly="readonly"
       :bootstrapStyling="bootstrapStyling"
       :use-utc="useUtc"
       @showCalendar="showCalendar"
@@ -149,7 +148,6 @@ export default {
     initialView: String,
     disabled: Boolean,
     required: Boolean,
-    readonly: Boolean,
     typeable: Boolean,
     useUtc: Boolean,
     minimumView: {

--- a/src/components/PickerMonth.vue
+++ b/src/components/PickerMonth.vue
@@ -181,8 +181,9 @@ export default {
       }
       if (typeof this.disabledDates.from !== 'undefined' && this.disabledDates.from) {
         if (
-          this.disabledDates.from &&
-          (this.utils.getMonth(date) > this.utils.getMonth(this.disabledDates.from) && this.utils.getFullYear(date) >= this.utils.getFullYear(this.disabledDates.from)) ||
+          (this.disabledDates.from &&
+            this.utils.getMonth(date) > this.utils.getMonth(this.disabledDates.from) &&
+            this.utils.getFullYear(date) >= this.utils.getFullYear(this.disabledDates.from)) ||
           this.utils.getFullYear(date) > this.utils.getFullYear(this.disabledDates.from)
         ) {
           disabledDates = true

--- a/test/unit/specs/Datepicker/Datepicker.spec.js
+++ b/test/unit/specs/Datepicker/Datepicker.spec.js
@@ -239,7 +239,7 @@ describe('Datepicker.vue set by timestamp', () => {
     wrapper = shallow(Datepicker, {
       propsData: {
         format: 'yyyy MM dd',
-        value: new Date(2018, 0, 29).getTime()
+        value: new Date(Date.UTC(2018, 0, 29, 0, 0, 0)).getTime()
       }
     })
     expect(wrapper.vm.selectedDate.getUTCFullYear()).toEqual(2018)
@@ -336,4 +336,3 @@ describe('Datepicker with initial-view', () => {
     expect(wrapper.vm.showYearView).toEqual(true)
   })
 })
-


### PR DESCRIPTION
Adding this attribute removes the caret from the text input and improves the behaviour when the datepicker is used on your phone. The caret is still there for Firefox but it works for Chrome and Safari. On phones the readonly attribute stops the keyboard from appearing, which is annoying if the date picker isn't typeable.

I also fixed a test that breaks when run in the eastern hemisphere and fixed some issues the linter identified.