### PR TITLE
Fix minor misspell in Spanish locale

### DIFF
--- a/src/locale/translations/es.js
+++ b/src/locale/translations/es.js
@@ -4,7 +4,7 @@ export default new Language(
   'Spanish',
   ['Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio', 'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre'],
   ['Ene', 'Feb', 'Mar', 'Abr', 'May', 'Jun', 'Jul', 'Ago', 'Sep', 'Oct', 'Nov', 'Dic'],
-  ['Dom', 'Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sab']
+  ['Dom', 'Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb']
 )
 // eslint-disable-next-line
 ;


### PR DESCRIPTION
Minor misspell for "Sábado".