### PR TITLE
correct language name of vi

### DIFF
--- a/src/locale/translations/vi.js
+++ b/src/locale/translations/vi.js
@@ -1,7 +1,7 @@
 import Language from '../Language'
 
 export default new Language(
-  'Vientnamese',
+  'Vietnamese',
   ['Tháng 1', 'Tháng 2', 'Tháng 3', 'Tháng 4', 'Tháng 5', 'Tháng 6', 'Tháng 7', 'Tháng 8', 'Tháng 9', 'Tháng 10', 'Tháng 11', 'Tháng 12'],
   ['T 01', 'T 02', 'T 03', 'T 04', 'T 05', 'T 06', 'T 07', 'T 08', 'T 09', 'T 10', 'T 11', 'T 12'],
   ['CN', 'Thứ 2', 'Thứ 3', 'Thứ 4', 'Thứ 5', 'Thứ 6', 'Thứ 7']


### PR DESCRIPTION
Fix spell of language name, "vietnamese" instead "vientnamese".