### PR TITLE
add slot for customize calendar footer

### DIFF
--- a/src/components/PickerDay.vue
+++ b/src/components/PickerDay.vue
@@ -24,6 +24,7 @@
           v-html="dayCellContent(day)"
           @click="selectDate(day)"></span>
     </div>
+    <slot name="afterCalendar"></slot>
   </div>
 </template>
 <script>


### PR DESCRIPTION
Often there is a need to add custom action buttons to the footer of the calendar. The presence of a slot in this area would be very appropriate
![](https://i1.wp.com/angularscript.com/wp-content/uploads/2015/11/Angular-Directive-For-Adding-Bootstrap-Datepicker-To-UI-Grid.jpg?resize=370%2C297&ssl=1)