### PR TITLE
Make the blur event available for custom handling

### DIFF
--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -23,7 +23,7 @@
       :bootstrapStyling="bootstrapStyling"
       :use-utc="useUtc"
       @showCalendar="showCalendar"
-      @closeCalendar="close"
+      @closeCalendar="close(true)"
       @typedDate="setTypedDate"
       @clearDate="clearDate">
       <slot name="afterDateInput" slot="afterDateInput"></slot>


### PR DESCRIPTION
For value saves when the control closes by clicking away when entering new date value through a keyboard, the blur event should be listened by the consumer of this control.