### PR TITLE
Closed event now fires if you click outside of the input

### DIFF
--- a/src/components/DateInput.vue
+++ b/src/components/DateInput.vue
@@ -136,7 +136,7 @@ export default {
         this.typedDate = null
       }
 
-      this.$emit('closeCalendar')
+      this.$emit('closeCalendar', true)
     },
     /**
      * emit a clearDate event


### PR DESCRIPTION
This fixes an issue where clicking outside of the datepicker closes the calendar but does not fire the `closed` event.