### PR TITLE
Fix typeable dates with custom format (non-US)

### DIFF
--- a/src/components/DateInput.vue
+++ b/src/components/DateInput.vue
@@ -114,14 +114,16 @@ export default {
         27, // escape
         13 // enter
       ].includes(event.keyCode)) {
-        this.input.blur()
+        this.input.blur();
       }
 
       if (this.typeable) {
-        const typedDate = Date.parse(this.input.value)
-        if (!isNaN(typedDate)) {
-          this.typedDate = this.input.value
-          this.$emit('typedDate', new Date(this.typedDate))
+        var parseableDate = this.parseableDate(this.input.value, this.format);
+        var parsedDate = Date.parse(parseableDate);
+        var test = new Date(parsedDate)
+        if (!isNaN(parsedDate)) {
+          this.typedDate = this.input.value;
+          this.$emit('typedDate', new Date(parsedDate));
         }
       }
     },
@@ -130,7 +132,8 @@ export default {
      * called once the input is blurred
      */
     inputBlurred () {
-      if (this.typeable && isNaN(Date.parse(this.input.value))) {
+      var parseableDate = this.parseableDate(this.input.value, this.format);
+      if (isNaN(Date.parse(parseableDate))) {
         this.clearDate()
         this.input.value = null
         this.typedDate = null
@@ -143,7 +146,29 @@ export default {
      */
     clearDate () {
       this.$emit('clearDate')
-    }
+    },
+
+     /**
+     * makes date parseable
+     * to use with international dates
+     */
+    parseableDate(datestr,formatstr) {
+      if (!(datestr && formatstr)) {return datestr;}
+      var splitter = formatstr.match(/\-|\/|\s|\./) || ['-']
+         ,df       = formatstr.split(splitter[0])
+         ,ds       = datestr.split(splitter[0])
+         ,ymd      = [0,0,0]
+         ,dat;
+      for (var i=0;i<df.length;i++){
+              if (/yyyy/i.test(df[i])) {ymd[0] = ds[i];}
+         else if (/mm/i.test(df[i]))   {ymd[1] = ds[i];}
+         else if (/dd/i.test(df[i]))   {ymd[2] = ds[i];}
+      }
+            
+      var timezone = new Date().toString().split(" ");
+      dat = ymd.join('-') + 'T00:00:00' + timezone[5].substr(3,5); //include timezone to avoid wrong dates after parse
+      return dat;
+    }    
   },
   mounted () {
     this.input = this.$el.querySelector('input')

--- a/test/unit/specs/DateInput/typedDates.spec.js
+++ b/test/unit/specs/DateInput/typedDates.spec.js
@@ -29,6 +29,21 @@ describe('DateInput', () => {
     expect(wrapper.vm.formattedValue).toEqual(dateString)
   })
 
+  it('allows international custom date format', () => {
+    const dateString = '24/06/2018'
+    wrapper.setProps({
+      selectedDate: new Date(dateString),
+      typeable: true,
+      format: 'dd/MM/yyyy'
+    })
+    const input = wrapper.find('input')
+    wrapper.vm.input.value = dateString
+    expect(wrapper.vm.input.value).toEqual(dateString)
+    input.trigger('keyup')
+    expect(wrapper.emitted().typedDate[0][0].toISOString()).toEqual('2018-06-24T03:00:00.000Z')
+    expect(wrapper.vm.formattedValue).toEqual(dateString)
+  })
+  
   it('emits the date when typed', () => {
     const input = wrapper.find('input')
     wrapper.vm.input.value = '2018-04-24'


### PR DESCRIPTION
As we were having problems in our project with typeable dates, we did this modification to make custom (non-US) dates parseable for Date.Parse.

We have added function, based on [Kooiinc's generic method to parse dates with different formats](https://stackoverflow.com/questions/9356846/generic-method-to-parse-date-with-different-formats/), to convert dates with custom format to generic format that can be parsed.  






