### PR TITLE
Translation of march

### DIFF
--- a/src/locale/translations/nl.js
+++ b/src/locale/translations/nl.js
@@ -3,7 +3,7 @@ import Language from '../Language'
 export default new Language(
   'Dutch',
   ['januari', 'februari', 'maart', 'april', 'mei', 'juni', 'juli', 'augustus', 'september', 'oktober', 'november', 'december'],
-  ['jan', 'feb', 'maa', 'apr', 'mei', 'jun', 'jul', 'aug', 'sep', 'okt', 'nov', 'dec'],
+  ['jan', 'feb', 'mrt', 'apr', 'mei', 'jun', 'jul', 'aug', 'sep', 'okt', 'nov', 'dec'],
   ['zo', 'ma', 'di', 'wo', 'do', 'vr', 'za']
 )
 // eslint-disable-next-line


### PR DESCRIPTION
March is written as 'mrt' in Dutch instead of 'maa'