### PR TITLE
Change disabledDates to disabled-dates in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ var state = {
   }
 }
 </script>
-<datepicker :disabledDates="state.disabledDates"></datepicker>
+<datepicker :disabled-dates="state.disabledDates"></datepicker>
 ```
 
 ## Highlighted Dates


### PR DESCRIPTION
While originally marked as fixed in https://github.com/charliekassel/vuejs-datepicker/issues/521, the correct syntax is kebab-case instead of camelCase in HTML attributes.

Using camelCase will make Vue show the following message in the console and the dates wont be disabled:

```
[Vue tip]: Prop "disableddates" is passed to component <Anonymous>, but the declared prop name is "disabledDates". Note that HTML attributes are case-insensitive and camelCased props need to use their kebab-case equivalents when using in-DOM templates. You should probably use "disabled-dates" instead of "disabledDates".
```

