### PR TITLE
Fix months/years falsely disabled by disabled-dates

### DIFF
--- a/example/Demo.vue
+++ b/example/Demo.vue
@@ -89,21 +89,13 @@
     </div>
 
     <div class="example">
+      <h3>Disabled dates</h3>
       <div class="settings">
         <h5>Settings</h5>
         <div class="form-group">
           <label>Disabled Function:</label>
         </div>
-        <pre>
-          disabledDates: {
-            customPredictor: function (date) {
-              // disables every day of a month which is a multiple of 3
-              if (date.getDate() % 3 === 0) {
-                return true
-              }
-            }
-          }
-        </pre>
+        <pre>{{ disabledFnContent }}</pre>
         <h5>Resulting Date picker</h5>
         <datepicker :disabledDates="disabledFn"></datepicker>
       </div>
@@ -270,11 +262,44 @@ export default {
       openDate: null,
       disabledFn: {
         customPredictor (date) {
-          if (date.getDate() % 3 === 0) {
+          const year = date.getFullYear()
+          const month = date.getMonth()
+          const day = date.getDate()
+
+          // disable every years that are a multiple of 2
+          if (year % 2 === 0) {
+            return true
+          }
+          // disable every months that are a multiple of 3
+          if (month % 3 === 0) {
+            return true
+          }
+          // disable first half of the month when it is a multiple of 2
+          if (month % 2 !== 0 && day < 15) {
             return true
           }
         }
       },
+      disabledFnContent: `disabledDates: {
+  customPredictor: function (date) {
+    const year = date.getFullYear()
+    const month = date.getMonth()
+    const day = date.getDate()
+
+    // disable every years that are a multiple of 2
+    if (year % 2 === 0) {
+      return true
+    }
+    // disable every months that are a multiple of 3
+    if (month % 3 === 0) {
+      return true
+    }
+    // disable first half of the month when it is a multiple of 2
+    if (month % 2 !== 0 && day < 15) {
+      return true
+    }
+  }
+}`,
       highlightedFn: {
         customPredictor (date) {
           if (date.getDate() % 4 === 0) {

--- a/src/components/PickerDay.vue
+++ b/src/components/PickerDay.vue
@@ -28,6 +28,7 @@
 </template>
 <script>
 import { makeDateUtils } from '../utils/DateUtils'
+import { isDateDisabled } from '../utils/DisabledDatesUtils'
 export default {
   props: {
     showDayView: Boolean,
@@ -237,46 +238,7 @@ export default {
      * @return {Boolean}
      */
     isDisabledDate (date) {
-      let disabledDates = false
-
-      if (typeof this.disabledDates === 'undefined') {
-        return false
-      }
-
-      if (typeof this.disabledDates.dates !== 'undefined') {
-        this.disabledDates.dates.forEach((d) => {
-          if (this.utils.compareDates(date, d)) {
-            disabledDates = true
-            return true
-          }
-        })
-      }
-      if (typeof this.disabledDates.to !== 'undefined' && this.disabledDates.to && date < this.disabledDates.to) {
-        disabledDates = true
-      }
-      if (typeof this.disabledDates.from !== 'undefined' && this.disabledDates.from && date > this.disabledDates.from) {
-        disabledDates = true
-      }
-      if (typeof this.disabledDates.ranges !== 'undefined') {
-        this.disabledDates.ranges.forEach((range) => {
-          if (typeof range.from !== 'undefined' && range.from && typeof range.to !== 'undefined' && range.to) {
-            if (date < range.to && date > range.from) {
-              disabledDates = true
-              return true
-            }
-          }
-        })
-      }
-      if (typeof this.disabledDates.days !== 'undefined' && this.disabledDates.days.indexOf(this.utils.getDay(date)) !== -1) {
-        disabledDates = true
-      }
-      if (typeof this.disabledDates.daysOfMonth !== 'undefined' && this.disabledDates.daysOfMonth.indexOf(this.utils.getDate(date)) !== -1) {
-        disabledDates = true
-      }
-      if (typeof this.disabledDates.customPredictor === 'function' && this.disabledDates.customPredictor(date)) {
-        disabledDates = true
-      }
-      return disabledDates
+      return isDateDisabled(date, this.disabledDates, this.utils)
     },
     /**
      * Whether a day is highlighted (only if it is not disabled already except when highlighted.includeDisabled is true)

--- a/src/components/PickerMonth.vue
+++ b/src/components/PickerMonth.vue
@@ -49,12 +49,26 @@ export default {
       let dObj = this.useUtc
         ? new Date(Date.UTC(d.getUTCFullYear(), 0, d.getUTCDate()))
         : new Date(d.getFullYear(), 0, d.getDate(), d.getHours(), d.getMinutes())
+
       for (let i = 0; i < 12; i++) {
+        // if at least one day of this month is NOT disabled,
+        // we can conclude that this month SHOULD be selectable
+        let daysInMonth = this.utils.daysInMonth(this.utils.getFullYear(dObj), this.utils.getMonth(dObj))
+        let monthIsDisabled = true
+        for (let j = 1; j <= daysInMonth; j++) {
+          let ddObj = new Date(dObj)
+          ddObj.setDate(j)
+          if (!this.isDisabledMonth(ddObj)) {
+            monthIsDisabled = false
+            break
+          }
+        }
+
         months.push({
           month: this.utils.getMonthName(i, this.translation.months),
           timestamp: dObj.getTime(),
           isSelected: this.isSelectedMonth(dObj),
-          isDisabled: this.isDisabledMonth(dObj)
+          isDisabled: monthIsDisabled
         })
         this.utils.setMonth(dObj, this.utils.getMonth(dObj) + 1)
       }

--- a/src/components/PickerMonth.vue
+++ b/src/components/PickerMonth.vue
@@ -21,6 +21,7 @@
 </template>
 <script>
 import { makeDateUtils } from '../utils/DateUtils'
+import { isMonthDisabled } from '../utils/DisabledDatesUtils'
 export default {
   props: {
     showMonthView: Boolean,
@@ -49,26 +50,12 @@ export default {
       let dObj = this.useUtc
         ? new Date(Date.UTC(d.getUTCFullYear(), 0, d.getUTCDate()))
         : new Date(d.getFullYear(), 0, d.getDate(), d.getHours(), d.getMinutes())
-
       for (let i = 0; i < 12; i++) {
-        // if at least one day of this month is NOT disabled,
-        // we can conclude that this month SHOULD be selectable
-        let daysInMonth = this.utils.daysInMonth(this.utils.getFullYear(dObj), this.utils.getMonth(dObj))
-        let monthIsDisabled = true
-        for (let j = 1; j <= daysInMonth; j++) {
-          let ddObj = new Date(dObj)
-          ddObj.setDate(j)
-          if (!this.isDisabledMonth(ddObj)) {
-            monthIsDisabled = false
-            break
-          }
-        }
-
         months.push({
           month: this.utils.getMonthName(i, this.translation.months),
           timestamp: dObj.getTime(),
           isSelected: this.isSelectedMonth(dObj),
-          isDisabled: monthIsDisabled
+          isDisabled: this.isDisabledMonth(dObj)
         })
         this.utils.setMonth(dObj, this.utils.getMonth(dObj) + 1)
       }
@@ -179,33 +166,7 @@ export default {
      * @return {Boolean}
      */
     isDisabledMonth (date) {
-      let disabledDates = false
-
-      if (typeof this.disabledDates === 'undefined') {
-        return false
-      }
-
-      if (typeof this.disabledDates.to !== 'undefined' && this.disabledDates.to) {
-        if (
-          (this.utils.getMonth(date) < this.utils.getMonth(this.disabledDates.to) && this.utils.getFullYear(date) <= this.utils.getFullYear(this.disabledDates.to)) ||
-          this.utils.getFullYear(date) < this.utils.getFullYear(this.disabledDates.to)
-        ) {
-          disabledDates = true
-        }
-      }
-      if (typeof this.disabledDates.from !== 'undefined' && this.disabledDates.from) {
-        if (
-          (this.utils.getMonth(date) > this.utils.getMonth(this.disabledDates.from) && this.utils.getFullYear(date) >= this.utils.getFullYear(this.disabledDates.from)) ||
-          this.utils.getFullYear(date) > this.utils.getFullYear(this.disabledDates.from)
-        ) {
-          disabledDates = true
-        }
-      }
-
-      if (typeof this.disabledDates.customPredictor === 'function' && this.disabledDates.customPredictor(date)) {
-        disabledDates = true
-      }
-      return disabledDates
+      return isMonthDisabled(date, this.disabledDates, this.utils)
     }
   }
 }

--- a/src/components/PickerYear.vue
+++ b/src/components/PickerYear.vue
@@ -22,6 +22,7 @@
 </template>
 <script>
 import { makeDateUtils } from '../utils/DateUtils'
+import { isYearDisabled } from '../utils/DisabledDatesUtils'
 export default {
   props: {
     showYearView: Boolean,
@@ -145,27 +146,7 @@ export default {
      * @return {Boolean}
      */
     isDisabledYear (date) {
-      let disabledDates = false
-      if (typeof this.disabledDates === 'undefined' || !this.disabledDates) {
-        return false
-      }
-
-      if (typeof this.disabledDates.to !== 'undefined' && this.disabledDates.to) {
-        if (this.utils.getFullYear(date) < this.utils.getFullYear(this.disabledDates.to)) {
-          disabledDates = true
-        }
-      }
-      if (typeof this.disabledDates.from !== 'undefined' && this.disabledDates.from) {
-        if (this.utils.getFullYear(date) > this.utils.getFullYear(this.disabledDates.from)) {
-          disabledDates = true
-        }
-      }
-
-      if (typeof this.disabledDates.customPredictor === 'function' && this.disabledDates.customPredictor(date)) {
-        disabledDates = true
-      }
-
-      return disabledDates
+      return isYearDisabled(date, this.disabledDates, this.utils)
     }
   }
 }

--- a/src/utils/DisabledDatesUtils.js
+++ b/src/utils/DisabledDatesUtils.js
@@ -1,0 +1,93 @@
+/**
+ * Checks if the given date should be disabled according to the specified config
+ * @param {Date} date
+ * @param {Object} disabledDates
+ * @param {DateUtils} utils
+ * @return {Boolean}
+ */
+export const isDateDisabled = function (date, disabledDates, utils) {
+  let disabled = false
+
+  if (typeof disabledDates === 'undefined') {
+    return false
+  }
+
+  if (typeof disabledDates.dates !== 'undefined') {
+    disabledDates.dates.forEach((d) => {
+      if (utils.compareDates(date, d)) {
+        disabled = true
+        return true
+      }
+    })
+  }
+  if (typeof disabledDates.to !== 'undefined' && disabledDates.to && date < disabledDates.to) {
+    disabled = true
+  }
+  if (typeof disabledDates.from !== 'undefined' && disabledDates.from && date > disabledDates.from) {
+    disabled = true
+  }
+  if (typeof disabledDates.ranges !== 'undefined') {
+    disabledDates.ranges.forEach((range) => {
+      if (typeof range.from !== 'undefined' && range.from && typeof range.to !== 'undefined' && range.to) {
+        if (date < range.to && date > range.from) {
+          disabled = true
+          return true
+        }
+      }
+    })
+  }
+  if (typeof disabledDates.days !== 'undefined' && disabledDates.days.indexOf(utils.getDay(date)) !== -1) {
+    disabled = true
+  }
+  if (typeof disabledDates.daysOfMonth !== 'undefined' && disabledDates.daysOfMonth.indexOf(utils.getDate(date)) !== -1) {
+    disabled = true
+  }
+  if (typeof disabledDates.customPredictor === 'function' && disabledDates.customPredictor(date)) {
+    disabled = true
+  }
+  return disabled
+}
+
+/**
+ * Checks if the given month should be disabled according to the specified config
+ * @param {Date} date
+ * @param {Object} disabledDates
+ * @param {DateUtils} utils
+ * @return {Boolean}
+ */
+export const isMonthDisabled = function (date, disabledDates, utils) {
+  // skip if no config
+  if (typeof disabledDates === 'undefined') {
+    return false
+  }
+
+  // check if the whole month is disabled before checking every individual days
+  if (typeof disabledDates.to !== 'undefined' && disabledDates.to) {
+    if (
+      (utils.getMonth(date) < utils.getMonth(disabledDates.to) && utils.getFullYear(date) <= utils.getFullYear(disabledDates.to)) ||
+      utils.getFullYear(date) < utils.getFullYear(disabledDates.to)
+    ) {
+      return true
+    }
+  }
+  if (typeof disabledDates.from !== 'undefined' && disabledDates.from) {
+    if (
+      (utils.getMonth(date) > utils.getMonth(disabledDates.from) && utils.getFullYear(date) >= utils.getFullYear(disabledDates.from)) ||
+      utils.getFullYear(date) > utils.getFullYear(disabledDates.from)
+    ) {
+      return true
+    }
+  }
+
+  // now we have to check every days of the month
+  let daysInMonth = utils.daysInMonth(utils.getFullYear(date), utils.getMonth(date))
+  for (let j = 1; j <= daysInMonth; j++) {
+    let dayDate = new Date(date)
+    dayDate.setDate(j)
+    // if at least one day of this month is NOT disabled, we can conclude that this month SHOULD be selectable
+    if (!isDateDisabled(dayDate, disabledDates, utils)) {
+      return false
+    }
+  }
+  return true
+}

--- a/src/utils/DisabledDatesUtils.js
+++ b/src/utils/DisabledDatesUtils.js
@@ -91,3 +91,40 @@ export const isMonthDisabled = function (date, disabledDates, utils) {
   }
   return true
 }
+
+/**
+ * Checks if the given year should be disabled according to the specified config
+ * @param {Date} date
+ * @param {Object} disabledDates
+ * @param {DateUtils} utils
+ * @return {Boolean}
+ */
+export const isYearDisabled = function (date, disabledDates, utils) {
+  // skip if no config
+  if (typeof disabledDates === 'undefined' || !disabledDates) {
+    return false
+  }
+
+  // check if the whole year is disabled before checking every individual months
+  if (typeof disabledDates.to !== 'undefined' && disabledDates.to) {
+    if (utils.getFullYear(date) < utils.getFullYear(disabledDates.to)) {
+      return true
+    }
+  }
+  if (typeof disabledDates.from !== 'undefined' && disabledDates.from) {
+    if (utils.getFullYear(date) > utils.getFullYear(disabledDates.from)) {
+      return true
+    }
+  }
+
+  // now we have to check every months of the year
+  for (let j = 0; j < 12; j++) {
+    let monthDate = new Date(date)
+    monthDate.setMonth(j)
+    // if at least one month of this year is NOT disabled, we can conclude that this year SHOULD be selectable
+    if (!isMonthDisabled(monthDate, disabledDates, utils)) {
+      return false
+    }
+  }
+  return true
+}

--- a/src/utils/DisabledDatesUtils.js
+++ b/src/utils/DisabledDatesUtils.js
@@ -6,46 +6,52 @@
  * @return {Boolean}
  */
 export const isDateDisabled = function (date, disabledDates, utils) {
-  let disabled = false
-
+  // skip if no config
   if (typeof disabledDates === 'undefined') {
     return false
   }
 
-  if (typeof disabledDates.dates !== 'undefined') {
-    disabledDates.dates.forEach((d) => {
-      if (utils.compareDates(date, d)) {
-        disabled = true
+  // check specific dates
+  if (typeof disabledDates.dates !== 'undefined' && disabledDates.dates.length) {
+    const dates = disabledDates.dates
+    for (let i = 0; i < dates.length; i++) {
+      if (utils.compareDates(date, dates[i])) {
         return true
       }
-    })
+    }
   }
+
   if (typeof disabledDates.to !== 'undefined' && disabledDates.to && date < disabledDates.to) {
-    disabled = true
+    return true
   }
   if (typeof disabledDates.from !== 'undefined' && disabledDates.from && date > disabledDates.from) {
-    disabled = true
+    return true
   }
-  if (typeof disabledDates.ranges !== 'undefined') {
-    disabledDates.ranges.forEach((range) => {
+
+  // check date ranges
+  if (typeof disabledDates.ranges !== 'undefined' && disabledDates.ranges.length) {
+    const ranges = disabledDates.ranges
+    for (let i = 0; i < ranges.length; i++) {
+      let range = ranges[i]
       if (typeof range.from !== 'undefined' && range.from && typeof range.to !== 'undefined' && range.to) {
         if (date < range.to && date > range.from) {
-          disabled = true
           return true
         }
       }
-    })
+    }
   }
+
   if (typeof disabledDates.days !== 'undefined' && disabledDates.days.indexOf(utils.getDay(date)) !== -1) {
-    disabled = true
+    return true
   }
   if (typeof disabledDates.daysOfMonth !== 'undefined' && disabledDates.daysOfMonth.indexOf(utils.getDate(date)) !== -1) {
-    disabled = true
+    return true
   }
   if (typeof disabledDates.customPredictor === 'function' && disabledDates.customPredictor(date)) {
-    disabled = true
+    return true
   }
-  return disabled
+
+  return false
 }
 
 /**


### PR DESCRIPTION
### The problem

The `month` view and the `year` view where checking if a specific month/year where disabled only by checking 1 day of each... (for `month` view it was the first day of the month and for `year` view it was the current day of the current month i think)

This means that if you have a month with the first day disabled, sorry :man_shrugging: , this month will be disabled in month view and it's whole year will be disabled in year view ! :confused: 

### What I did

So I've centralized the logic associated with the `disabled-dates` prop in a separated file, and there should be no more falsely disabled stuff because I check everything from year, to month do individual days. It goes about like this : 

1. is this year out of the from/to ranges ?
2. ok then I'll check if each months are out of from/to ranges
3. then I'll check if any day is not disabled

And basically, as soon as something is saying "I'm not disabled", it stops and don't reach the more granular checks. I hope my explanation is clear enough ?

### Related

This fixes issue #588 

