### PR TITLE
Table-like borders in PickerDay

### DIFF
--- a/src/components/PickerDay.vue
+++ b/src/components/PickerDay.vue
@@ -22,7 +22,8 @@
           :key="day.timestamp"
           :class="dayClasses(day)"
           v-html="dayCellContent(day)"
-          @click="selectDate(day)"></span>
+          @click="selectDate(day)"></span><!--
+      --><span class="cell day blank" v-for="n in blankAppend" :key="'blank-append' + n"></span>
     </div>
   </div>
 </template>
@@ -82,6 +83,16 @@ export default {
         return this.utils.getDay(dObj) > 0 ? this.utils.getDay(dObj) - 1 : 6
       }
       return this.utils.getDay(dObj)
+    },
+    blankAppend () {
+      let dayCellsCount = this.days.length + this.blankDays
+      if (dayCellsCount === 28 || dayCellsCount === 35 || dayCellsCount === 42) {
+        return 0
+      } else if (dayCellsCount < 35) {
+        return 35 - dayCellsCount
+      } else {
+        return 42 - dayCellsCount
+      }
     },
     /**
      * @return {Object[]}

--- a/test/unit/specs/PickerDay/cellsAmount.spec.js
+++ b/test/unit/specs/PickerDay/cellsAmount.spec.js
@@ -1,0 +1,39 @@
+import PickerDay from '@/components/PickerDay.vue'
+import {shallow} from '@vue/test-utils'
+import {en} from '@/locale'
+
+describe('PickerDay: DOM table-like structure', () => {
+  it('should render 28 cells', () => {
+    let wrapper = shallow(PickerDay, {
+      propsData: {
+        allowedToShowView: () => true,
+        translation: en,
+        pageDate: new Date(2015, 1, 1),
+        selectedDate: new Date(2015, 1, 1)
+      }
+    })
+    expect(wrapper.findAll('.day')).toHaveLength(28)
+  })
+  it('should render 35 cells', () => {
+    let wrapper = shallow(PickerDay, {
+      propsData: {
+        allowedToShowView: () => true,
+        translation: en,
+        pageDate: new Date(2019, 6, 1),
+        selectedDate: new Date(2019, 6, 1)
+      }
+    })
+    expect(wrapper.findAll('.day')).toHaveLength(35)
+  })
+  it('should render 42 cells', () => {
+    let wrapper = shallow(PickerDay, {
+      propsData: {
+        allowedToShowView: () => true,
+        translation: en,
+        pageDate: new Date(2019, 5, 1),
+        selectedDate: new Date(2019, 5, 1)
+      }
+    })
+    expect(wrapper.findAll('.day')).toHaveLength(42)
+  })
+})


### PR DESCRIPTION
Thanks again for this great datepicker!
I needed to add borders to the PickerDay component. Like this:
![table-like](https://user-images.githubusercontent.com/24456439/59929245-19547680-9449-11e9-99bd-b3380abdaefc.jpg)
This can be done with css, but trailing "blank days" are missing and grid is incomplete. 
I added missing blank days in the end of the day table and provided tests.