### PR TITLE
Make button behavior the same as input field

### DIFF
--- a/src/components/DateInput.vue
+++ b/src/components/DateInput.vue
@@ -2,12 +2,12 @@
   <div :class="{'input-group' : bootstrapStyling}">
     <!-- Calendar Button -->
     <span v-if="calendarButton" class="vdp-datepicker__calendar-button" :class="{'input-group-prepend' : bootstrapStyling}" @click="showCalendar" v-bind:style="{'cursor:not-allowed;' : disabled}">
-      <span :class="{'input-group-text' : bootstrapStyling}">
+      <button type="button" :class="{'input-group-text' : bootstrapStyling}" @blur="inputBlurred">
         <i :class="calendarButtonIcon">
           {{ calendarButtonIconContent }}
           <span v-if="!calendarButtonIcon">&hellip;</span>
         </i>
-      </span>
+      </button>
     </span>
     <!-- Input -->
     <input


### PR DESCRIPTION
If we have several Datepickers with button and click on both buttons sequentially then both Datepickers will appear and overlap one each other.

![image](https://user-images.githubusercontent.com/1325864/60667789-0e4f0c80-9e73-11e9-9d8b-08470e5767a8.png)


This patch fixes such issue.