### PR TITLE
Date-time picker view

### DIFF
--- a/example/Demo.vue
+++ b/example/Demo.vue
@@ -246,6 +246,14 @@
       </code>
     </div>
 
+    <div class="example">
+      <h3>DateTime </h3>
+      <datepicker placeholder="Select Date" :time="true" />
+      <code>
+          &lt;datepicker :time="true" placeholder="Select Date"&gt;&lt;/datepicker&gt;
+      </code>
+    </div>
+
   </div>
 </template>
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "serve": "rollup -c scripts/serve.js --watch",
     "test": "jest --config test/unit/jest.conf.js --coverage",
     "lint": "eslint --ext .js,.vue src test/unit/specs",
+    "fix": "eslint --fix --ext .js,.vue src test/unit/specs",
     "prepublishOnly": "npm run build"
   },
   "pre-commit": [

--- a/src/components/PickerDay.vue
+++ b/src/components/PickerDay.vue
@@ -27,7 +27,7 @@
     <footer class="day__time_foot" v-if="time"  @click="showTimeCalendar" :class="allowedToShowView('time') ? 'up' : ''">
       <slot name="timeButton">
         
-        <span class="day__time_btn">Time</span>
+        <span class="day__time_btn">{{hours}}</span>
         
       </slot>
     </footer>
@@ -64,6 +64,14 @@ export default {
     }
   },
   computed: {
+
+    hours () {
+      if (!this.selectedDate) {
+        return '--:--'
+      }
+      return `${this.utils.getHours(this.selectedDate)}:${this.utils.getMinutes(this.selectedDate)}`
+    },
+
     /**
      * Returns an array of day names
      * @return {String[]}

--- a/src/components/PickerDay.vue
+++ b/src/components/PickerDay.vue
@@ -24,6 +24,13 @@
           v-html="dayCellContent(day)"
           @click="selectDate(day)"></span>
     </div>
+    <footer class="day__time_foot" v-if="time"  @click="showTimeCalendar" :class="allowedToShowView('time') ? 'up' : ''">
+      <slot name="timeButton">
+        
+        <span class="day__time_btn">Time</span>
+        
+      </slot>
+    </footer>
   </div>
 </template>
 <script>
@@ -47,7 +54,8 @@ export default {
     translation: Object,
     isRtl: Boolean,
     mondayFirst: Boolean,
-    useUtc: Boolean
+    useUtc: Boolean,
+    time: Boolean
   },
   data () {
     const constructedDateUtils = makeDateUtils(this.useUtc)
@@ -167,6 +175,12 @@ export default {
      */
     getPageMonth () {
       return this.utils.getMonth(this.pageDate)
+    },
+    /**
+     * Emit an event to show the time picker
+     */
+    showTimeCalendar () {
+      this.$emit('showTimeCalendar')
     },
     /**
      * Emit an event to show the month picker

--- a/src/components/PickerTime.vue
+++ b/src/components/PickerTime.vue
@@ -1,0 +1,65 @@
+<template>
+  <div :class="[calendarClass, 'vdp-datepicker__calendar']" v-show="showTimeView" :style="calendarStyle" @mousedown.prevent>
+    <slot name="beforeCalendarHeader"></slot>
+    <header>
+        <div class="day__calendar_btn" @click="showDayCalendar" :class="allowedToShowView('day') ? 'up' : ''">{{ formattedValue }}</div>
+    </header>
+        <span class="cell time" @click="setHours(1)">up</span><span class="cell"></span><span class="cell time" @click="setMinutes(1)">up</span>
+        <span class="cell time">{{utils.getHours(selectedDate)}}</span><span class="cell">:</span><span class="cell time">{{utils.getMinutes(selectedDate)}}</span>
+        <span class="cell time" @click="setHours(-1)">down</span><span class="cell"></span><span class="cell time" @click="setMinutes(-1)">down</span>
+  </div>
+</template>
+<script>
+import { makeDateUtils } from '../utils/DateUtils'
+export default {
+  props: {
+    showTimeView: Boolean,
+    selectedDate: Date,
+    format: [String, Function],
+    allowedToShowView: Function,
+    calendarClass: [String, Object, Array],
+    calendarStyle: Object,
+    useUtc: Boolean,
+    translation: Object
+  },
+  data () {
+    const constructedDateUtils = makeDateUtils(this.useUtc)
+    return {
+      utils: constructedDateUtils
+    }
+  },
+  computed: {
+    formattedValue () {
+      if (!this.selectedDate) {
+        return null
+      }
+      return typeof this.format === 'function'
+        ? this.format(this.selectedDate)
+        : this.utils.formatDate(new Date(this.selectedDate), this.format, this.translation)
+    }
+  },
+  methods: {
+
+    setHours (incrementBy) {
+      let date = this.selectedDate
+      this.utils.setHours(date, this.utils.getHours(date) + incrementBy)
+
+      this.$emit('selectDate', {date: date, timestamp: date.getTime()})
+    },
+    setMinutes (incrementBy) {
+      let date = this.selectedDate
+      this.utils.setMinutes(date, this.utils.getMinutes(date) + incrementBy)
+
+      this.$emit('selectDate', {date: date, timestamp: date.getTime()})
+    },
+    /**
+     * Emit an event to show the day picker
+     */
+    showDayCalendar () {
+      this.$emit('showDayCalendar')
+    }
+  }
+}
+// eslint-disable-next-line
+;
+</script>

--- a/src/components/PickerTime.vue
+++ b/src/components/PickerTime.vue
@@ -4,9 +4,9 @@
     <header>
         <div class="day__calendar_btn" @click="showDayCalendar" :class="allowedToShowView('day') ? 'up' : ''">{{ formattedValue }}</div>
     </header>
-        <span class="cell time" @click="setHours(1)">up</span><span class="cell"></span><span class="cell time" @click="setMinutes(1)">up</span>
+        <span class="cell time time_up" @click="setHours(1)">up</span><span class="cell"> </span><span class="cell time time_up" @click="setMinutes(1)">up</span>
         <span class="cell time">{{utils.getHours(selectedDate)}}</span><span class="cell">:</span><span class="cell time">{{utils.getMinutes(selectedDate)}}</span>
-        <span class="cell time" @click="setHours(-1)">down</span><span class="cell"></span><span class="cell time" @click="setMinutes(-1)">down</span>
+        <span class="cell time time_down" @click="setHours(-1)">down</span><span class="cell"> </span><span class="cell time time_down" @click="setMinutes(-1)">down</span>
   </div>
 </template>
 <script>

--- a/src/styles/style.styl
+++ b/src/styles/style.styl
@@ -12,6 +12,17 @@
     background white
     width 300px
     border 1px solid #ccc
+    footer
+        display block
+        line-height 40px
+        text-align center
+        span
+            display inline-block
+            text-align center
+            width 100%
+            cursor pointer
+            &:hover
+                background #eee
     header
         display block
         line-height 40px
@@ -110,6 +121,37 @@
         width 33.333%
     .time
         width ((100/7)*3)%
+
+    .time_up
+    .time_down
+        text-indent -10000px
+        position relative
+        &:after
+            content ''
+            position absolute
+            left 50%
+            top 50%
+            transform translateX(-50%) translateY(-50%)
+            border 6px solid transparent
+
+    .time_up
+        &:after
+            border-bottom 10px solid #000
+            margin-bottom -5px
+        &.disabled:after
+            border-bottom 10px solid #ddd
+    .time_down
+        &:after
+            border-top 10px solid #000
+            margin-top 5px
+        &.disabled:after
+            border-top 10px solid #ddd
+
+    .time_up:not(.disabled)
+    .time_down:not(.disabled)
+        cursor pointer
+        &:hover
+            background #eee
 
 .vdp-datepicker__clear-button
 .vdp-datepicker__calendar-button

--- a/src/styles/style.styl
+++ b/src/styles/style.styl
@@ -20,6 +20,8 @@
             text-align center
             width (100 - (100/7)*2)%
             float left
+        div
+            text-align center
 
         .prev
         .next
@@ -72,6 +74,7 @@
         text-align center
         vertical-align middle
         border 1px solid transparent
+        &:not(.blank):not(.disabled).time
         &:not(.blank):not(.disabled).day
         &:not(.blank):not(.disabled).month
         &:not(.blank):not(.disabled).year
@@ -101,10 +104,12 @@
             cursor inherit
             &:hover
                 background inherit
-
+  
     .month,
     .year
         width 33.333%
+    .time
+        width ((100/7)*3)%
 
 .vdp-datepicker__clear-button
 .vdp-datepicker__calendar-button

--- a/src/utils/DateUtils.js
+++ b/src/utils/DateUtils.js
@@ -78,6 +78,22 @@ const utils = {
     return this.useUtc ? date.setUTCDate(value) : date.setDate(value)
   },
 
+   /**
+   * Sets the hours, using UTC or not
+   * @param {Date} date
+   */
+  setHours (date, value, useUtc) {
+    return this.useUtc ? date.setUTCHours(value) : date.setHours(value)
+  },
+
+  /**
+   * Sets the minutes, using UTC or not
+   * @param {Date} date
+   */
+  setMinutes (date, value, useUtc) {
+    return this.useUtc ? date.setUTCMinutes(value) : date.setMinutes(value)
+  },
+
   /**
    * Check if date1 is equivalent to date2, without comparing the time
    * @see https://stackoverflow.com/a/6202196/4455925

--- a/test/unit/specs/DateUtils.spec.js
+++ b/test/unit/specs/DateUtils.spec.js
@@ -175,6 +175,18 @@ describe('UTC functions', () => {
     expect(utcUtils.setMonth(date, 11)).toEqual(date.setUTCMonth(11))
   })
 
+  it('setHours', () => {
+    const date = getAmbiguousDate()
+    expect(DateUtils.setHours(date, 11)).toEqual(date.setHours(11))
+    expect(utcUtils.setHours(date, 11)).toEqual(date.setUTCHours(11))
+  })
+
+  it('setMinutes', () => {
+    const date = getAmbiguousDate()
+    expect(DateUtils.setMinutes(date, 11)).toEqual(date.setMinutes(11))
+    expect(utcUtils.setMinutes(date, 11)).toEqual(date.setUTCMinutes(11))
+  })
+
   it('setDate', () => {
     const date = getAmbiguousDate()
     expect(DateUtils.setDate(date, 31)).toEqual(date.setDate(31))

--- a/test/unit/specs/Datepicker/Datepicker.spec.js
+++ b/test/unit/specs/Datepicker/Datepicker.spec.js
@@ -20,7 +20,7 @@ describe('Datepicker unmounted', () => {
 
 describe('Datepicker mounted', () => {
   let wrapper
-  let wrapperWithTimeEnabled
+
   let date
   beforeEach(() => {
     date = new Date(2016, 1, 15)
@@ -28,13 +28,6 @@ describe('Datepicker mounted', () => {
       propsData: {
         format: 'yyyy-MM-dd',
         value: date
-      }
-    })
-    wrapperWithTimeEnabled = shallow(Datepicker, {
-      propsData: {
-        format: 'yyyy-MM-dd',
-        value: date,
-        time: true
       }
     })
   })
@@ -109,8 +102,11 @@ describe('Datepicker mounted', () => {
     wrapper.vm.showTimeCalendar()
     expect(wrapper.vm.isOpen).toEqual(false)
 
-    wrapperWithTimeEnabled.vm.showTimeCalendar()
-    expect(wrapperWithTimeEnabled.vm.isOpen).toEqual(true)
+    wrapper.setProps({
+      time: true
+    })
+    wrapper.vm.showTimeCalendar()
+    expect(wrapper.vm.isOpen).toEqual(true)
 
     wrapper.vm.close()
     expect(wrapper.vm.isOpen).toEqual(false)

--- a/test/unit/specs/Datepicker/Datepicker.spec.js
+++ b/test/unit/specs/Datepicker/Datepicker.spec.js
@@ -20,6 +20,7 @@ describe('Datepicker unmounted', () => {
 
 describe('Datepicker mounted', () => {
   let wrapper
+  let wrapperWithTimeEnabled
   let date
   beforeEach(() => {
     date = new Date(2016, 1, 15)
@@ -27,6 +28,13 @@ describe('Datepicker mounted', () => {
       propsData: {
         format: 'yyyy-MM-dd',
         value: date
+      }
+    })
+    wrapperWithTimeEnabled = shallow(Datepicker, {
+      propsData: {
+        format: 'yyyy-MM-dd',
+        value: date,
+        time: true
       }
     })
   })
@@ -96,6 +104,15 @@ describe('Datepicker mounted', () => {
     expect(wrapper.vm.isOpen).toEqual(true)
     // calendar is already open so acts as a toggle
     wrapper.vm.showCalendar()
+    expect(wrapper.vm.isOpen).toEqual(false)
+
+    wrapper.vm.showTimeCalendar()
+    expect(wrapper.vm.isOpen).toEqual(false)
+
+    wrapperWithTimeEnabled.vm.showTimeCalendar()
+    expect(wrapperWithTimeEnabled.vm.isOpen).toEqual(true)
+
+    wrapper.vm.close()
     expect(wrapper.vm.isOpen).toEqual(false)
   })
 

--- a/test/unit/specs/PickerDay/pickerDay.spec.js
+++ b/test/unit/specs/PickerDay/pickerDay.spec.js
@@ -10,7 +10,8 @@ describe('PickerDay: DOM', () => {
         allowedToShowView: () => true,
         translation: en,
         pageDate: new Date(2018, 1, 1),
-        selectedDate: new Date(2018, 2, 24)
+        selectedDate: new Date(2018, 2, 24),
+        time: true
       }
     })
   })
@@ -33,9 +34,15 @@ describe('PickerDay: DOM', () => {
     expect(wrapper.vm.getPageMonth()).toEqual(1)
   })
 
-  it('emits show year calendar event when clicked on the year', () => {
-    const yearBtn = wrapper.find('.day__month_btn')
-    yearBtn.trigger('click')
+  it('emits show month calendar event when clicked on the month', () => {
+    const monthBtn = wrapper.find('.day__month_btn')
+    monthBtn.trigger('click')
     expect(wrapper.emitted().showMonthCalendar).toBeTruthy()
+  })
+
+  it('emits show time calendar event when clicked on the time', () => {
+    const timeBtn = wrapper.find('.day__time_foot')
+    timeBtn.trigger('click')
+    expect(wrapper.emitted().showTimeCalendar).toBeTruthy()
   })
 })

--- a/test/unit/specs/PickerDay/pickerDay.spec.js
+++ b/test/unit/specs/PickerDay/pickerDay.spec.js
@@ -16,6 +16,18 @@ describe('PickerDay: DOM', () => {
     })
   })
 
+  it('knows the selected hour', () => {
+    const newDate = new Date(2016, 9, 15, 15, 15)
+    wrapper.setProps({
+      selectedDate: newDate
+    })
+    expect(wrapper.vm.hours).toEqual('15:15')
+    wrapper.setProps({
+      selectedDate: null
+    })
+    expect(wrapper.vm.hours).toEqual('--:--')
+  })
+
   it('knows the selected date', () => {
     const newDate = new Date(2016, 9, 15)
     wrapper.setProps({

--- a/test/unit/specs/PickerTime/pickerTime.spec.js
+++ b/test/unit/specs/PickerTime/pickerTime.spec.js
@@ -1,0 +1,82 @@
+import PickerTime from '@/components/PickerTime.vue'
+import {shallow} from '@vue/test-utils'
+import {en} from '@/locale'
+
+describe('PickerTime', () => {
+  let wrapper
+  beforeEach(() => {
+    wrapper = shallow(PickerTime, {
+      propsData: {
+        allowedToShowView: () => true,
+        translation: en,
+        format: 'yyyy-MM-dd',
+        pageDate: new Date(2018, 1, 1),
+        selectedDate: new Date(2018, 2, 24)
+      }
+    })
+  })
+
+  it('knows the selected date', () => {
+    expect(wrapper.vm.formattedValue).not.toBe(null)
+    wrapper.setProps({
+      selectedDate: null
+    })
+    expect(wrapper.vm.formattedValue).toEqual(null)
+  })
+
+  it('emits date on change minutes', () => {
+    wrapper.vm.setMinutes(1)
+    expect(wrapper.emitted().selectDate).toBeTruthy()
+    expect(wrapper.emitted().selectDate[0][0].timestamp).not.toBe(undefined)
+  })
+
+  it('add minutes', () => {
+    const baseDate = new Date()
+    wrapper.setProps({
+      selectedDate: baseDate
+    })
+    const time = baseDate.getTime()
+    const timePlusOne = new Date(time).setMinutes(baseDate.getMinutes() + 1)
+    wrapper.vm.setMinutes(1)
+    expect(wrapper.emitted().selectDate[0][0].timestamp).toEqual(timePlusOne)
+  })
+
+  it('decrease minutes', () => {
+    const baseDate = new Date()
+    wrapper.setProps({
+      selectedDate: baseDate
+    })
+    const time = baseDate.getTime()
+    const timeMinusOne = new Date(time).setMinutes(baseDate.getMinutes() - 1)
+    wrapper.vm.setMinutes(-1)
+    expect(wrapper.emitted().selectDate[0][0].timestamp).toEqual(timeMinusOne)
+  })
+
+  it('add hours', () => {
+    const baseDate = new Date()
+    wrapper.setProps({
+      selectedDate: baseDate
+    })
+    const time = baseDate.getTime()
+    const timePlusOne = new Date(time).setHours(baseDate.getHours() + 1)
+    wrapper.vm.setHours(1)
+    expect(wrapper.emitted().selectDate[0][0].timestamp).toEqual(timePlusOne)
+  })
+
+  it('decrease hours', () => {
+    const baseDate = new Date()
+    wrapper.setProps({
+      selectedDate: baseDate
+    })
+    const time = baseDate.getTime()
+    const timeMinusOne = new Date(time).setHours(baseDate.getHours() - 1)
+    wrapper.vm.setHours(-1)
+    expect(wrapper.emitted().selectDate[0][0].timestamp).toEqual(timeMinusOne)
+  })
+
+  it('emits show day calendar event when clicked on the day', () => {
+    const dayBtn = wrapper.find('.day__calendar_btn')
+    dayBtn.trigger('click')
+    expect(wrapper.emitted().showDayCalendar).toBeTruthy()
+  })
+})

--- a/test/unit/specs/PickerTime/pickerTime.spec.js
+++ b/test/unit/specs/PickerTime/pickerTime.spec.js
@@ -10,7 +10,6 @@ describe('PickerTime', () => {
         allowedToShowView: () => true,
         translation: en,
         format: 'yyyy-MM-dd',
-        pageDate: new Date(2018, 1, 1),
         selectedDate: new Date(2018, 2, 24)
       }
     })


### PR DESCRIPTION
Hi!
This PR enables the user to view a date-time picker after enabling it as a prop.

When enabled the `time` prop a footer will be showed in PickerDay 
![image](https://user-images.githubusercontent.com/15440218/60709048-c4683400-9f0f-11e9-8c97-1ff8f6368af1.png)

When clicked a new view is presented to the user

![image](https://user-images.githubusercontent.com/15440218/60709079-dea21200-9f0f-11e9-8fba-6492efed53dc.png)

by clicking on the date you can return to the day view.