### PR TITLE
Allow overriding of default input selector

### DIFF
--- a/example/Demo.vue
+++ b/example/Demo.vue
@@ -246,6 +246,22 @@
       </code>
     </div>
 
+    <div class="example">
+      <h3>Custom toggle</h3>
+      <p>{{ hiddenDate }}</p>
+      <datepicker hideInput v-model="hiddenDate">
+        <template v-slot:toggle-button="scopedProps">
+          <button title="Toggle" @click="scopedProps.picker.toggle">Change date</button>
+        </template>
+      </datepicker>
+      <code>
+        &lt;datepicker&gt;
+          &lt;template slot=&quot;toggle-button&quot; slot-scope=&quot;picker&quot;&gt;
+            &lt;button title=&quot;Open&quot;&gt;Change date&lt;/button&gt;
+          &lt;/template&gt;
+        &lt;/datepicker&gt;
+      </code>
+    </div>
   </div>
 </template>
 
@@ -287,7 +303,8 @@ export default {
       state: state,
       vModelExample: null,
       languages: lang,
-      language: 'en'
+      language: 'en',
+      hiddenDate: new Date()
     }
   },
   computed: {

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="vdp-datepicker" :class="[wrapperClass, isRtl ? 'rtl' : '']">
     <date-input
+      v-if="!hideInput"
       :selectedDate="selectedDate"
       :resetTypedDate="resetTypedDate"
       :format="format"
@@ -29,6 +30,9 @@
       <slot name="afterDateInput" slot="afterDateInput"></slot>
     </date-input>
 
+    <slot name="toggle-button" v-bind:picker="{
+      toggle: showCalendar
+    }" />
 
     <!-- Day View -->
     <picker-day
@@ -124,6 +128,10 @@ export default {
     },
     openDate: {
       validator: val => utils.validateDateInput(val)
+    },
+    hideInput: {
+      type: Boolean,
+      default: false
     },
     dayCellContent: Function,
     fullMonthName: Boolean,


### PR DESCRIPTION
This PR allows you to use `<template v-slot:toggle-button>` to override the default input box and use your own component (e.g a button) to open the datepicker