### PR TITLE
Fix parsing of typed input with use-utc=true

### DIFF
--- a/src/components/DateInput.vue
+++ b/src/components/DateInput.vue
@@ -118,7 +118,7 @@ export default {
       }
 
       if (this.typeable) {
-        const typedDate = Date.parse(this.input.value)
+        const typedDate = this.utils.parseDate(this.input.value)
         if (!isNaN(typedDate)) {
           this.typedDate = this.input.value
           this.$emit('typedDate', new Date(typedDate))
@@ -130,7 +130,7 @@ export default {
      * called once the input is blurred
      */
     inputBlurred () {
-      if (this.typeable && isNaN(Date.parse(this.input.value))) {
+      if (this.typeable && isNaN(this.utils.parseDate(this.input.value))) {
         this.clearDate()
         this.input.value = null
         this.typedDate = null

--- a/src/components/DateInput.vue
+++ b/src/components/DateInput.vue
@@ -121,7 +121,7 @@ export default {
         const typedDate = Date.parse(this.input.value)
         if (!isNaN(typedDate)) {
           this.typedDate = this.input.value
-          this.$emit('typedDate', new Date(this.typedDate))
+          this.$emit('typedDate', new Date(typedDate))
         }
       }
     },

--- a/src/utils/DateUtils.js
+++ b/src/utils/DateUtils.js
@@ -219,6 +219,15 @@ const utils = {
   },
 
   /**
+   * Parses date string into milliseconds, using UTC or not
+   * @param {String} dateString
+   * @return {Number}
+   */
+  parseDate (dateString) {
+    return Date.parse(this.useUtc ? dateString + ' UTC' : dateString)
+  },
+
+  /**
    * Creates an array of dates for each day in between two dates.
    * @param {Date} start
    * @param {Date} end

--- a/test/unit/specs/DateUtils.spec.js
+++ b/test/unit/specs/DateUtils.spec.js
@@ -180,4 +180,11 @@ describe('UTC functions', () => {
     expect(DateUtils.setDate(date, 31)).toEqual(date.setDate(31))
     expect(utcUtils.setDate(date, 31)).toEqual(date.setUTCDate(31))
   })
+
+  it('parseDate', () => {
+    const date = '2018/11/30'
+    expect((new Date(DateUtils.parseDate(date))).getDate()).toEqual(30)
+    expect((new Date(utcUtils.parseDate(date))).getUTCDate()).toEqual(30)
+    expect(utcUtils.parseDate(date)).toEqual(DateUtils.parseDate(date) - (new Date(utcUtils.parseDate(date))).getTimezoneOffset() * 60 * 1000)
+  })
 })


### PR DESCRIPTION
Date.parse assumes non-UTC dates by default, which results in incorrect date calculation with use-utc=true. As Date.parse itself has no UTC variant, fix this problem by appending " UTC" into the end of the date to designate the timezone of the parsed object.

This fixed at least #666 and may also fix some other issues.
