### PR TITLE
Update Datepicker.vue

### DIFF
--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -215,6 +215,7 @@ export default {
 
     calendarStyle () {
       return {
+        bottom: !this.isInline && window.innerHeight - this.$el.getBoundingClientRect().bottom < 375 ? (this.$el.getBoundingClientRect().bottom - this.$el.getBoundingClientRect().top + 2) + "px" : "auto",
         position: this.isInline ? 'static' : undefined
       }
     },


### PR DESCRIPTION
add some calculations to the calendarStyle computed that will dynamically move the calendar to above the input box when it is close to the bottom of the screen