### PR TITLE
Update ca.js to comply with the catalan linguistic regulations

### DIFF
--- a/src/locale/translations/ca.js
+++ b/src/locale/translations/ca.js
@@ -3,8 +3,8 @@ import Language from '../Language'
 export default new Language(
   'Catalan',
   ['Gener', 'Febrer', 'Març', 'Abril', 'Maig', 'Juny', 'Juliol', 'Agost', 'Setembre', 'Octubre', 'Novembre', 'Desembre'],
-  ['Gen', 'Feb', 'Mar', 'Abr', 'Mai', 'Jun', 'Jul', 'Ago', 'Set', 'Oct', 'Nov', 'Des'],
-  ['Diu', 'Dil', 'Dmr', 'Dmc', 'Dij', 'Div', 'Dis']
+  ['GN', 'FB', 'MÇ', 'AB', 'MG', 'JN', 'JL', 'AG', 'ST', 'OC', 'NV', 'DS'],
+  ['Dg.', 'Dl.', 'Dt.', 'Dc.', 'Dj.', 'Dv.', 'Ds.']
 )
 // eslint-disable-next-line
 ;


### PR DESCRIPTION
Add appropriate week days abbreviation.

According to the [catalan regulations](https://aplicacions.llengua.gencat.cat/llc/AppJava/index.html?action=Principal&method=detall&input_cercar=abreviatures+mesos&numPagina=1&database=FITXES_PUB&idFont=8402&idHit=8402&tipusFont=Fitxes+de+l%2527Optimot&numeroResultat=1&databases_avansada=&categories_avansada=&clickLink=detall&titol=abreviatures+dels+mesos+de+l%2527any&tematica=&tipusCerca=cerca.normes), some months have no abbreviation, however it is accepted to use month codes instead.