### PR TITLE
convert mondayFirst prop to firstDayOfWeek

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Inline always open version
 | calendar-class                | String\|Object  |             | CSS class applied to the calendar el     |
 | input-class                   | String\|Object  |             | CSS class applied to the input el        |
 | wrapper-class                 | String\|Object  |             | CSS class applied to the outer div       |
-| monday-first                  | Boolean         | false       | To start the week on Monday              |
+| first-day-of-week             | Number          | 0           | To start the week a specific day         |
 | clear-button                  | Boolean         | false       | Show an icon for clearing the date       |
 | clear-button-icon             | String          |             | Use icon for button (ex: fa fa-times)    |
 | calendar-button               | Boolean         | false       | Show an icon that that can be clicked    |

--- a/example/Demo.vue
+++ b/example/Demo.vue
@@ -2,6 +2,20 @@
   <div id="app">
     <h1>Datepicker Examples</h1>
     <div class="example">
+      <h3>
+        Datepicker with firstDayOfWeek set to {{ languages[language].days[firstDayOfWeek] }}
+      </h3>
+      <datepicker placeholder="Select Date" :firstDayOfWeek="firstDayOfWeek"/>
+      <code>
+          &lt;datepicker placeholder="Select Date" firstDayOfWeek="{{firstDayOfWeek}}"&gt;&lt;/datepicker&gt;
+      </code>
+
+      <select v-model="firstDayOfWeek">
+        <option :value="key" v-for="(day, key) in languages[language].days" :key="key">{{ day }}</option>
+      </select>
+    </div>
+
+    <div class="example">
       <h3>Default datepicker...</h3>
       <datepicker placeholder="Select Date" />
       <code>
@@ -287,7 +301,8 @@ export default {
       state: state,
       vModelExample: null,
       languages: lang,
-      language: 'en'
+      language: 'en',
+      firstDayOfWeek: 3,
     }
   },
   computed: {

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -45,7 +45,7 @@
       :translation="translation"
       :pageTimestamp="pageTimestamp"
       :isRtl="isRtl"
-      :mondayFirst="mondayFirst"
+      :firstDayOfWeek="firstDayOfWeek"
       :dayCellContent="dayCellContent"
       :use-utc="useUtc"
       @changedMonth="handleChangedMonthFromDayPicker"
@@ -134,7 +134,7 @@ export default {
     calendarClass: [String, Object, Array],
     inputClass: [String, Object, Array],
     wrapperClass: [String, Object, Array],
-    mondayFirst: Boolean,
+    firstDayOfWeek: Number,
     clearButton: Boolean,
     clearButtonIcon: String,
     calendarButton: Boolean,

--- a/src/components/PickerDay.vue
+++ b/src/components/PickerDay.vue
@@ -46,7 +46,7 @@ export default {
     calendarStyle: Object,
     translation: Object,
     isRtl: Boolean,
-    mondayFirst: Boolean,
+    firstDayOfWeek: Number,
     useUtc: Boolean
   },
   data () {
@@ -61,9 +61,11 @@ export default {
      * @return {String[]}
      */
     daysOfWeek () {
-      if (this.mondayFirst) {
+      if (this.firstDayOfWeek) {
         const tempDays = this.translation.days.slice()
-        tempDays.push(tempDays.shift())
+        for (var i = 0; i < this.firstDayOfWeek; i++) {
+          tempDays.push(tempDays.shift())
+        }
         return tempDays
       }
       return this.translation.days
@@ -78,8 +80,21 @@ export default {
       let dObj = this.useUtc
         ? new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1))
         : new Date(d.getFullYear(), d.getMonth(), 1, d.getHours(), d.getMinutes())
-      if (this.mondayFirst) {
-        return this.utils.getDay(dObj) > 0 ? this.utils.getDay(dObj) - 1 : 6
+      if (this.firstDayOfWeek) {
+        const offset = this.utils.getDay(dObj) - this.firstDayOfWeek
+        return offset < 0 ? 7 + offset : offset
+        // This should return a number of days visible from previous month according to this table
+        // Where X is the actual dayoftheweek for the first of the month,
+        // and Y is the firstDayOfWeek prop
+        //   0 1 2 3 4 5 6 
+        // 0 0 1 2 3 4 5 6
+        // 1 6 0 1 2 3 4 5
+        // 2 5 6 0 1 2 3 4
+        // 3 4 5 6 0 1 2 3
+        // 4 3 4 5 6 0 1 2
+        // 5 2 3 4 5 6 0 1
+        // 6 1 2 3 4 5 6 0
+
       }
       return this.utils.getDay(dObj)
     },

--- a/test/unit/specs/PickerDay/mondayFirst.spec.js
+++ b/test/unit/specs/PickerDay/mondayFirst.spec.js
@@ -7,7 +7,7 @@ describe('PickerDay: Datepicker with monday as first day of week', () => {
   beforeEach(() => {
     wrapper = shallow(PickerDay, {
       propsData: {
-        mondayFirst: true,
+        firstDayOfWeek: 1,
         translation: en,
         allowedToShowView: () => true,
         pageDate: new Date(2018, 1, 1)


### PR DESCRIPTION
Let calendar support any day of week as the firstDayOfWeek.

I haven't changed the mondayFirst test as it is still a valid test case, but it now uses firstDayOfWeek to test using Monday as the first day.