### PR TITLE
Add ability to hide the DateInput entirely

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Inline always open version
 | open-date                     | Date\|String    |             | If set, open on that date                |
 | minimum-view                  | String          | 'day'       | If set, lower-level views won't show     |
 | maximum-view                  | String          | 'year'      | If set, higher-level views won't show    |
-
+| date-input-visible            | Boolean         | true        | Sets visibility of DateInput             |
 
 ## Events
 

--- a/src/components/DateInput.vue
+++ b/src/components/DateInput.vue
@@ -146,7 +146,7 @@ export default {
     }
   },
   mounted () {
-    this.input = this.$el.querySelector('input')
+    if (this.$el && this.$el.querySelector) this.input = this.$el.querySelector('input')
   }
 }
 // eslint-disable-next-line

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="vdp-datepicker" :class="[wrapperClass, isRtl ? 'rtl' : '']">
     <date-input
+      v-if="dateInputVisible"
       :selectedDate="selectedDate"
       :resetTypedDate="resetTypedDate"
       :format="format"
@@ -153,6 +154,10 @@ export default {
     maximumView: {
       type: String,
       default: 'year'
+    },
+    dateInputVisible: {
+      type: Boolean,
+      default: true
     }
   },
   data () {


### PR DESCRIPTION
I ran into a situation, where I wanted to show the Calendar picker, but did not want to display the DateInput element at all.

 So proposing a new prop 'date-input-visible', to provide a v-if conditional on the DateInput.

Also I needed to add a guard in the DatePicker.vue mounted as querySelector will not exist, if the <input> element never renders.