### PR TITLE
'opened' event is now emitted

### DIFF
--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -250,6 +250,8 @@ export default {
       }
       if (this.isOpen) {
         return this.close(true)
+      } else {
+        this.$emit('opened', null)
       }
       this.setInitialView()
     },

--- a/test/unit/specs/Datepicker/Datepicker.spec.js
+++ b/test/unit/specs/Datepicker/Datepicker.spec.js
@@ -99,6 +99,11 @@ describe('Datepicker mounted', () => {
     expect(wrapper.vm.isOpen).toEqual(false)
   })
 
+  it('should emit opened on calendar open', () => {
+    wrapper.vm.showCalendar()
+    expect(wrapper.emitted().opened).toBeTruthy()
+  })
+
   it('should emit selectedDisabled on a disabled timestamp', () => {
     const date = new Date(2016, 9, 1)
     wrapper.vm.selectDisabledDate({timestamp: date.getTime()})


### PR DESCRIPTION
It's a fix for:
https://github.com/charliekassel/vuejs-datepicker/issues/744

The 'opened' is now emitted.