### PR TITLE
Added component name

### DIFF
--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -29,7 +29,6 @@
       <slot name="afterDateInput" slot="afterDateInput"></slot>
     </date-input>
 
-
     <!-- Day View -->
     <picker-day
       v-if="allowedToShowView('day')"
@@ -101,6 +100,7 @@ import PickerMonth from './PickerMonth.vue'
 import PickerYear from './PickerYear.vue'
 import utils, { makeDateUtils } from '../utils/DateUtils'
 export default {
+  name: 'datepicker',
   components: {
     DateInput,
     PickerDay,


### PR DESCRIPTION
What about to add a `name` property to component definition?

When you define the component as global, almost all components are defined as:

```javascript
import Datepicker from 'vuejs-datepicker';

Vue.component(Datepicker.name, Datepicker);
```

Regards,
Lito.