### PR TITLE
Typing information and opened event

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,4 @@
+import Vue, { Component } from 'vue'
+
+export default class Datepicker extends Vue {
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "types": "index.d.ts",
   "unpkg": "dist/vuejs-datepicker.min.js",
   "files": [
+    "index.d.ts",
     "src",
     "dist"
   ],

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   ],
   "main": "dist/vuejs-datepicker.js",
   "module": "dist/vuejs-datepicker.esm.js",
+  "types": "index.d.ts",
   "unpkg": "dist/vuejs-datepicker.min.js",
   "files": [
     "src",

--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -23,7 +23,7 @@
       :bootstrapStyling="bootstrapStyling"
       :use-utc="useUtc"
       @showCalendar="showCalendar"
-      @closeCalendar="close"
+      @closeCalendar="close(true)"
       @typedDate="setTypedDate"
       @clearDate="clearDate">
       <slot name="afterDateInput" slot="afterDateInput"></slot>
@@ -252,6 +252,7 @@ export default {
         return this.close(true)
       }
       this.setInitialView()
+      this.$emit('opened')
     },
     /**
      * Sets the initial picker page view: day, month or year

--- a/test/unit/specs/Datepicker/Datepicker.spec.js
+++ b/test/unit/specs/Datepicker/Datepicker.spec.js
@@ -245,12 +245,12 @@ describe('Datepicker.vue set by timestamp', () => {
     wrapper = shallow(Datepicker, {
       propsData: {
         format: 'yyyy MM dd',
-        value: new Date(Date.UTC(2018, 0, 29)).getTime()
+        value: new Date(Date.UTC(2018, 1, 28)).getTime()
       }
     })
     expect(wrapper.vm.selectedDate.getFullYear()).toEqual(2018)
-    expect(wrapper.vm.selectedDate.getMonth()).toEqual(0)
-    expect(wrapper.vm.selectedDate.getDate()).toEqual(29)
+    expect(wrapper.vm.selectedDate.getMonth()).toEqual(1)
+    expect(wrapper.vm.selectedDate.getUTCDate()).toEqual(28)
   })
 })
 


### PR DESCRIPTION
This pull request adds two features to the component:
- Typing information for use in typescript environments
- The documentation makes reference to an "opened" event that is fired when the calendar element is opened. However, the component did not actually fire that event ever. So the emit for the event was added in the appropriate place, and now the behavior of the code matches the documentation.