### PR TITLE
Add scope to customPredictor

### DIFF
--- a/src/components/PickerDay.vue
+++ b/src/components/PickerDay.vue
@@ -273,7 +273,7 @@ export default {
       if (typeof this.disabledDates.daysOfMonth !== 'undefined' && this.disabledDates.daysOfMonth.indexOf(this.utils.getDate(date)) !== -1) {
         disabledDates = true
       }
-      if (typeof this.disabledDates.customPredictor === 'function' && this.disabledDates.customPredictor(date)) {
+      if (typeof this.disabledDates.customPredictor === 'function' && this.disabledDates.customPredictor(date, 'day')) {
         disabledDates = true
       }
       return disabledDates

--- a/src/components/PickerMonth.vue
+++ b/src/components/PickerMonth.vue
@@ -188,7 +188,7 @@ export default {
         }
       }
 
-      if (typeof this.disabledDates.customPredictor === 'function' && this.disabledDates.customPredictor(date)) {
+      if (typeof this.disabledDates.customPredictor === 'function' && this.disabledDates.customPredictor(date, 'month')) {
         disabledDates = true
       }
       return disabledDates

--- a/src/components/PickerYear.vue
+++ b/src/components/PickerYear.vue
@@ -161,7 +161,7 @@ export default {
         }
       }
 
-      if (typeof this.disabledDates.customPredictor === 'function' && this.disabledDates.customPredictor(date)) {
+      if (typeof this.disabledDates.customPredictor === 'function' && this.disabledDates.customPredictor(date, 'year')) {
         disabledDates = true
       }
 


### PR DESCRIPTION
Hello, thanks for making this awesome library!

I realized as I was using it that when you disable dates using a customPredictor, that certain months and even years may become disabled. This is because the plugin checks the first date to see if it's disabled, rather than checking if any day in the given month/year is enabled. Makes total sense from a performance perspective in case the computation is heavy!

What I've done is simply added a second parameter to `customPredictor` which lets us know what scope we're dealing with. So, let's say I wanted to only allow certain days of the week, I can ensure that the scope is `day` before I say to disable the other dates. If the scope is anything else I can just always allow it.