### PR TITLE
Fix typo in language name

### DIFF
--- a/src/locale/translations/sl-SI.js
+++ b/src/locale/translations/sl-SI.js
@@ -1,7 +1,7 @@
 import Language from '../Language'
 
 export default new Language(
-  'Sloveian',
+  'Slovenian',
   ['Januar', 'Februar', 'Marec', 'April', 'Maj', 'Junij', 'Julij', 'Avgust', 'September', 'Oktober', 'November', 'December'],
   ['Jan', 'Feb', 'Mar', 'Apr', 'Maj', 'Jun', 'Jul', 'Avg', 'Sep', 'Okt', 'Nov', 'Dec'],
   ['Ned', 'Pon', 'Tor', 'Sre', 'Čet', 'Pet', 'Sob']


### PR DESCRIPTION
The country is Slovenia, the Language is Slovenian - this commit fixes the typo.

Question: Slovenian isn't the main language in any other country, so only `sl.js` was expected. Spanish has `es.js` (Spanish, no location given) and not `es-ES.js` (Spanish-Spain), while other variants would also exist (Spanish Mexican, Costa rican, Colombian, Panama,... about 20 in total).

Can we rename `sl-SI` to `sl`? The ICU Locale `sl` is valid: https://www.localeplanet.com/java/sl/index.html