### PR TITLE
Add spec for 'PickerDay: disabled' to clarify its spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Dates can be disabled in a number of ways.
 <script>
 var state = {
   disabledDates: {
-    to: new Date(2016, 0, 5), // Disable all dates up to specific date
+    to: new Date(2016, 0, 5), // Disable all dates before specific date
     from: new Date(2016, 0, 26), // Disable all dates after specific date
     days: [6, 0], // Disable Saturday's and Sunday's
     daysOfMonth: [29, 30, 31], // Disable 29th, 30th and 31st of each month

--- a/test/unit/specs/PickerDay/disabledDates.spec.js
+++ b/test/unit/specs/PickerDay/disabledDates.spec.js
@@ -24,6 +24,11 @@ describe('PickerDay: disabled', () => {
     expect(wrapper.vm.isDisabledDate(new Date(2016, 9, 27))).toEqual(true)
   })
 
+  it('should not disable disabledDates.to and disabledDates.from', () => {
+    expect(wrapper.vm.isDisabledDate(new Date(2016, 9, 4))).toEqual(false)
+    expect(wrapper.vm.isDisabledDate(new Date(2016, 9, 26))).toEqual(false)
+  })
+
   it('should not select a disabled date', () => {
     expect(wrapper.vm.selectDate({isDisabled: true})).toEqual(false)
   })

--- a/test/unit/specs/PickerDay/disabledDates.spec.js
+++ b/test/unit/specs/PickerDay/disabledDates.spec.js
@@ -20,8 +20,8 @@ describe('PickerDay: disabled', () => {
   })
 
   it('should detect a disabled date', () => {
-    expect(wrapper.vm.isDisabledDate(new Date(2006, 9, 2))).toEqual(true)
-    expect(wrapper.vm.isDisabledDate(new Date(2026, 9, 2))).toEqual(true)
+    expect(wrapper.vm.isDisabledDate(new Date(2016, 9, 3))).toEqual(true)
+    expect(wrapper.vm.isDisabledDate(new Date(2016, 9, 27))).toEqual(true)
   })
 
   it('should not select a disabled date', () => {


### PR DESCRIPTION
I've modified README and added test cases since the README and specs didn't tell about `disabledDates`'s boundary conditions.