### PR TITLE
chore : fixed month abbreviation on month only picker

### DIFF
--- a/src/components/Datepicker.vue
+++ b/src/components/Datepicker.vue
@@ -63,6 +63,7 @@
       :showMonthView="showMonthView"
       :allowedToShowView="allowedToShowView"
       :disabledDates="disabledDates"
+      :fullMonthName="fullMonthName"
       :calendarClass="calendarClass"
       :calendarStyle="calendarStyle"
       :translation="translation"

--- a/src/components/PickerMonth.vue
+++ b/src/components/PickerMonth.vue
@@ -29,6 +29,7 @@ export default {
     pageTimestamp: Number,
     disabledDates: Object,
     calendarClass: [String, Object, Array],
+    fullMonthName: { type: Boolean, default: () => true },
     calendarStyle: Object,
     translation: Object,
     isRtl: Boolean,
@@ -51,7 +52,7 @@ export default {
         : new Date(d.getFullYear(), 0, d.getDate(), d.getHours(), d.getMinutes())
       for (let i = 0; i < 12; i++) {
         months.push({
-          month: this.utils.getMonthName(i, this.translation.months),
+          month: this.fullMonthName ? this.utils.getMonthName(i, this.translation.months) : this.utils.getMonthNameAbbr(i, this.translation.monthsAbbr),
           timestamp: dObj.getTime(),
           isSelected: this.isSelectedMonth(dObj),
           isDisabled: this.isDisabledMonth(dObj)


### PR DESCRIPTION
Reference issues
#713 

What does it fix?

It fixes the month abbreviation issue, allows you to pass a prop if you want to see the full month name or not