### PR TITLE
Triggers "closed" event on clicking NOT on the datepicker.

### DIFF
--- a/src/components/DateInput.vue
+++ b/src/components/DateInput.vue
@@ -136,7 +136,7 @@ export default {
         this.typedDate = null
       }
 
-      this.$emit('closeCalendar')
+      this.$emit('closeCalendar', true)
     },
     /**
      * emit a clearDate event


### PR DESCRIPTION
I wanted to make a custom validation with the datepicker inside it. The call of the closed event was not triggered at all. I followed the initial emit of the input blur event. Then I have found out that it closes the datepicker but does not emit the "closed" event because it does not pass _true_ argument.